### PR TITLE
Dropbox, scanning the alt_email field as well as the email field, for Leads and Contacts

### DIFF
--- a/lib/fat_free_crm/dropbox.rb
+++ b/lib/fat_free_crm/dropbox.rb
@@ -248,6 +248,10 @@ module FatFreeCRM
       attached = false
       ASSETS.each do |klass|
         asset = klass.find_by_email(recipient)
+        # Leads and Contacts have an alt_email
+        unless asset or klass == Account 
+          asset = klass.find_by_alt_email(recipient) 
+        end
         if asset && sender_has_permissions_for?(asset)
           attach(email, asset)
           attached = true


### PR DESCRIPTION
Dropbox, scanning the alt_email field as well as the email field, for Leads and Contacts
