### PR TITLE
Fix user delete

### DIFF
--- a/app/views/admin/users/_confirm.html.haml
+++ b/app/views/admin/users/_confirm.html.haml
@@ -1,5 +1,5 @@
 .confirm[@user, :confirm]
   #{t :user_confirm_delete}
   #{t :delete} <b>#{@user.full_name}</b>?
-  = link_to_delete(@user) << " : "
+  = link_to_delete(@user, :url => admin_user_path(@user))  << " : "
   = link_to_function(t(:no_button), "crm.flick('#{dom_id(@user, :confirm)}', 'remove')")


### PR DESCRIPTION
link_to_delete(@user) in app/views/admin/users/_confirm.html.haml works with UsersController, not with Admin::UsersController.

In UsersController
  def destroy
    # not exposed
  end

This way we getting error with user delete method.
