### PR TITLE
Small tweak for respond_to_not_found error message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -183,7 +183,12 @@ private
       else self.action_name
     end
     if self.action_name == "show"
-      flash[:warning] = t(:msg_asset_not_available, asset)
+      # If asset does exist, but is not viewable to the current user..
+      if asset.capitalize.constantize.exists?(params[:id])
+        flash[:warning] = t(:msg_asset_not_authorized, asset)
+      else
+        flash[:warning] = t(:msg_asset_not_available, asset)
+      end
     else
       flash[:warning] = t(:msg_cant_do, :action => flick, :asset => asset)
     end

--- a/config/locales/en-US_fat_free_crm.yml
+++ b/config/locales/en-US_fat_free_crm.yml
@@ -160,6 +160,7 @@ en-US:
   msg_account_not_approved: Your account has not been approved yet.
   msg_asset_deleted: "%{value} has been deleted."
   msg_asset_not_available: This %{value} is no longer available.
+  msg_asset_not_authorized: You are not authorized to view this %{value}.
   msg_assets_not_available: The %{value} are not available.
   msg_asset_rejected: "%{value} has been rejected."
   msg_bad_image_file: "^Could't upload or resize the image file you specified."


### PR DESCRIPTION
Was debugging an issue and I realized that I simply didn't have permissions to view the record. 
This conditional error message makes it a lot clearer.
