### PR TITLE
Fixed accout contact information help text

### DIFF
--- a/app/views/accounts/_contact_info.html.haml
+++ b/app/views/accounts/_contact_info.html.haml
@@ -3,7 +3,7 @@
 = subtitle :account_contact, collapsed, t(:contact_info)
 .section
   %small#account_contact_intro{ hidden_if(!collapsed) }
-    = t(:intro, t(:lead_small)) unless edit
+    = t(:intro, t(:account_small)) unless edit
   #account_contact{ hidden_if(collapsed) }
     %table{ :width => 500, :cellpadding => 0, :cellspacing => 0 }
       %tr


### PR DESCRIPTION
I noticed on that the prompt to expand the contact information for accounts said lead.
