### PR TITLE
"Create" link at top right is not translated

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -91,7 +91,7 @@ module ApplicationHelper
 
   #----------------------------------------------------------------------------
   def link_to_inline(id, url, options = {})
-    text = options[:text] || id.to_s.titleize
+    text = options[:text] || t(id).to_s.titleize
     text = (arrow_for(id) + text) unless options[:plain]
     related = (options[:related] ? "+'&related=#{options[:related]}'" : '')
 


### PR DESCRIPTION
Hi,
foton translated FF CRM into czech language and found that "arrowed link to create item" is not translated.
Fix is to edit method link_to_inline() in application_helper.rb 
instead of

 def link_to_inline(id, url, options = {})
    text = options[:text] || id.to_s.titleize
    .....
 end
there should be:

def link_to_inline(id, url, options = {})
  text = options[:text] || t(id).to_s.titleize
  .....
end
