### PR TITLE
Fix for issue #68

### DIFF
--- a/app/views/layouts/admin/application.html.haml
+++ b/app/views/layouts/admin/application.html.haml
@@ -4,7 +4,7 @@
     %meta{ "http-equiv" => "Content-Type", :content => "text/html; charset=utf-8" }
     %title= t(:crm_admin_page)
     == <!-- #{controller.controller_name} : #{controller.action_name} -->
-    = stylesheet_link_tag "screen", "modalbox.css", :cache => "cache/all"
+    = stylesheet_link_tag "screen", "modalbox.css"
     = stylesheet_link_tag "print", :media => "print"
     %style= yield :styles
 


### PR DESCRIPTION
Fix template error. I noticed the cache part was omitted in the standard layout but left in in the admin layout. As the file is generated into the /tmp directory, Rails' standard caching doesn't work.
