### PR TITLE
rake crm:setup depends on settings already being present

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 FatFreeCRM::Application.routes.draw do
-  scope Setting.base_url.blank? ? "/" : Setting.base_url do
+  scope (!Setting.table_exists? || Setting.base_url.blank?) ? "/" : Setting.base_url do
     root :to => 'home#index'
 
     match 'activities' => 'home#index'


### PR DESCRIPTION
'routes.rb's reference to Setting.base_url causes a circular dependency when running 'rake crm:setup' on an empty database. Allow using default when the table does not yet exist.
