### PR TITLE
fixing rake ffcrm:setup

### DIFF
--- a/lib/tasks/fat_free_crm.rake
+++ b/lib/tasks/fat_free_crm.rake
@@ -72,7 +72,7 @@ namespace :ffcrm do
     # Migrating plugins is not part of Rails 3 yet, but it is coming. See
     # https://rails.lighthouseapp.com/projects/8994/tickets/2058 for details.
     Rake::Task["db:migrate:plugins"].invoke rescue nil
-    Rake::Task["setup:admin"].invoke
+    Rake::Task["ffcrm:setup:admin"].invoke
   end
 
   namespace :setup do


### PR DESCRIPTION
this fixed `bundle exec rake ffcrm:setup` for me (ruby 1.9.3-p125/bundler 1.1)
