### PR TITLE
Make specs pass if "Setting.locale" is not set to "en-US"

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,10 +54,11 @@ Spork.prefork do
 
     config.before(:each) do
       PaperTrail.enabled = false
-    end
-
-    config.before(:each, :type => :view) do
+      
+      # Overwrite locale settings within "config/settings.yml" if necessary.
+      # In order to ensure that test still pass if "Setting.locale" is not set to "en-US".
       I18n.locale = 'en-US'
+      Setting.locale = 'en-US' unless Setting.locale == 'en-US'
     end
 
     config.after(:each, :type => :view) do


### PR DESCRIPTION
For example:

If you set locale to "de" within "config/settings.yml" file some controller and view spec will fail! 
