### PR TITLE
Fixed mysql2 empty query exception if "sql" string is empty

### DIFF
--- a/db/migrate/20120314080441_add_subscribed_users_to_entities.rb
+++ b/db/migrate/20120314080441_add_subscribed_users_to_entities.rb
@@ -19,6 +19,6 @@ class AddSubscribedUsersToEntities < ActiveRecord::Migration
       sql << "UPDATE #{entity[0].tableize} SET subscribed_users = '#{user_ids.to_a.to_yaml}' WHERE id = #{entity[1]}; "
     end
 
-    connection.execute sql
+    connection.execute(sql) unless sql.empty?
   end
 end


### PR DESCRIPTION
Happens on an initial migration.
Exception mysql2 empty query is thrown if "sql" is an empty string.
