### PR TITLE
Fixed mysql syntax error exception (update subscribed_users)

### DIFF
--- a/db/migrate/20120314080441_add_subscribed_users_to_entities.rb
+++ b/db/migrate/20120314080441_add_subscribed_users_to_entities.rb
@@ -12,13 +12,12 @@ class AddSubscribedUsersToEntities < ActiveRecord::Migration
     Comment.all.each do |comment|
       entity_subscribers[[comment.commentable_type, comment.commentable_id]] += [comment.user_id]
     end
-
-    # Generate SQL query to update subscribed_users
-    sql = ""
-    entity_subscribers.each do |entity, user_ids|
-      sql << "UPDATE #{entity[0].tableize} SET subscribed_users = '#{user_ids.to_a.to_yaml}' WHERE id = #{entity[1]}; "
+    
+    # Run as one atomic action.
+    ActiveRecord::Base.transaction do
+      entity_subscribers.each do |entity, user_ids|
+        connection.execute "UPDATE #{entity[0].tableize} SET subscribed_users = '#{user_ids.to_a.to_yaml}' WHERE id = #{entity[1]}"
+      end
     end
-
-    connection.execute sql
   end
 end


### PR DESCRIPTION
If you have already data in the database and you run the migration, you will get a "mysql" syntax error (Migration update subscribed users) if you use a mysql database.

I would recommend to use a transaction:
- All updates run as one atomic action
- Performance
- String may not hold the query, if for example you must update 2000 records or more?
