### PR TITLE
Use transaction to change subscribed users

### DIFF
--- a/db/migrate/20120405080727_change_subscribed_users_to_set.rb
+++ b/db/migrate/20120405080727_change_subscribed_users_to_set.rb
@@ -5,19 +5,20 @@ class ChangeSubscribedUsersToSet < ActiveRecord::Migration
       FROM contacts
       WHERE subscribed_users IS NOT NULL
     }
-
-    sql = contacts.map do |contact|
-      subscribed_users_set = Set.new(YAML.load(contact["subscribed_users"]))
-      %Q{
-        UPDATE contacts
-        SET subscribed_users = '#{subscribed_users_set.to_yaml}'
-        WHERE id = #{contact["id"]}
-      }
-    end
-
-    if sql.any?
-      puts "Converting #{contacts.size} subscribed_users arrays into sets..."
-      connection.execute sql.join(";")
+    
+    puts "Converting #{contacts.size} subscribed_users arrays into sets..." unless contacts.empty?
+    
+    # Run as one atomic action.
+    ActiveRecord::Base.transaction do
+      for contact in contacts
+        subscribed_users_set = Set.new(YAML.load(contact["subscribed_users"]))
+      
+        connection.execute %Q{
+          UPDATE contacts
+          SET subscribed_users = '#{subscribed_users_set.to_yaml}'
+          WHERE id = #{contact["id"]}
+        }
+      end
     end
   end
 end

--- a/db/migrate/20120405080742_change_further_subscribed_users_to_set.rb
+++ b/db/migrate/20120405080742_change_further_subscribed_users_to_set.rb
@@ -7,19 +7,20 @@ class ChangeFurtherSubscribedUsersToSet < ActiveRecord::Migration
         FROM #{table}
         WHERE subscribed_users IS NOT NULL
       }
-
-      sql = entities.map do |entity|
-        subscribed_users_set = Set.new(YAML.load(entity["subscribed_users"]))
-        %Q{
-          UPDATE #{table}
-          SET subscribed_users = '#{subscribed_users_set.to_yaml}'
-          WHERE id = #{entity["id"]}
-        }
-      end
-
-      if sql.any?
-        puts "#{table}: Converting #{entities.size} subscribed_users arrays into sets..."
-        connection.execute sql.join(";")
+      
+      puts "#{table}: Converting #{entities.size} subscribed_users arrays into sets..." unless entities.empty?
+      
+      # Run as one atomic action.
+      ActiveRecord::Base.transaction do
+        for entity in entities
+          subscribed_users_set = Set.new(YAML.load(entity["subscribed_users"]))
+          
+          connection.execute %Q{
+            UPDATE #{table}
+            SET subscribed_users = '#{subscribed_users_set.to_yaml}'
+            WHERE id = #{entity["id"]}
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
In mysql the combination sql string with YAML inside always throws an exception.
So I replaced it with a transaction.

But in the database there is stored a strange YAML value inside subscribed_users column:

--- !ruby/object:Set 
hash: 
  3: true

Is this correct?
