### PR TITLE
Set default access on account

### DIFF
--- a/app/controllers/entities/opportunities_controller.rb
+++ b/app/controllers/entities/opportunities_controller.rb
@@ -43,7 +43,7 @@ class OpportunitiesController < EntitiesController
   def new
     @opportunity.attributes = {:user => @current_user, :stage => "prospecting", :access => Setting.default_access}
     @users       = User.except(@current_user)
-    @account     = Account.new(:user => @current_user)
+    @account     = Account.new(:user => @current_user, :access => Setting.default_access)
     @accounts    = Account.my.order('name')
 
     if params[:related]


### PR DESCRIPTION
We should set the "access" attribute of an account within "OpportunitiesController#new" to the default access configured within the settings.
