### PR TITLE
Fix password reset page UI

### DIFF
--- a/app/views/passwords/new.html.haml
+++ b/app/views/passwords/new.html.haml
@@ -1,5 +1,5 @@
 .standalone
-  - form_tag(passwords_path, one_submit_only(:passwords)) do
+  = form_tag(passwords_path, one_submit_only(:passwords)) do
     .title #{t :forgot_password}
     .intro #{t :password_intro}
     .section


### PR DESCRIPTION
The password reset page's form_tag is prefixed with a '-' instead of a '=', preventing the content from being displayed.
