### PR TITLE
Completed tasks displaying as overdue in the dashboard

### DIFF
--- a/app/models/polymorphic/task.rb
+++ b/app/models/polymorphic/task.rb
@@ -72,8 +72,8 @@ class Task < ActiveRecord::Base
   }
 
   scope :visible_on_dashboard, lambda { |user|
-    # Show opportunities which either belong to the user and are unassigned, or are assigned to the user
-    where('(user_id = :user_id AND assigned_to IS NULL) OR assigned_to = :user_id', :user_id => user.id)
+    # Show tasks which aren't completed and either belong to the user and are unassigned, or are assigned to the user
+    where('completed_at IS NULL AND ((user_id = :user_id AND assigned_to IS NULL) OR assigned_to = :user_id)', :user_id => user.id)
   }
 
   scope :by_due_at, order({

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -30,6 +30,14 @@ describe HomeController do
       assigns[:my_tasks].should == [task_1, task_2, task_3, task_4]
     end
 
+		it "should not display completed tasks" do
+			task_1 = FactoryGirl.create(:task, :user_id => @current_user.id, :name => "Your first task", :bucket => "due_asap", :assigned_to => @current_user.id)
+			task_2 = FactoryGirl.create(:task, :user_id => @current_user.id, :name => "Completed task", :bucket => "due_asap", :completed_at => 1.days.ago, :completed_by => @current_user.id, :assigned_to => @current_user.id)
+
+			get :index
+			assigns[:my_tasks].should == [task_1]
+		end
+
     it "should get a list of my opportunities ordered by closes_on" do
       opportunity_1 = FactoryGirl.create(:opportunity, :name => "Your first opportunity", :closes_on => 15.days.from_now, :assigned_to => @current_user.id)
       opportunity_2 = FactoryGirl.create(:opportunity, :name => "Another opportunity for you", :closes_on => 10.days.from_now, :assigned_to => @current_user.id)


### PR DESCRIPTION
Noticed an issue where completed tasks for an Opportunity were displaying as overdue in the dashboard - have added a test case and fix for this which passes the test case.
