### PR TITLE
Fix problem with create task on specific date

### DIFF
--- a/app/views/tasks/_pending.html.haml
+++ b/app/views/tasks/_pending.html.haml
@@ -33,7 +33,7 @@
             = t(:task_overdue)
             = l(pending.due_at.localtime, :format => :mmddhhss)
           - else
-            = t(:task_due_in, distance_of_time_in_words(Time.now, pending.due_at))
+            = t(:task_due_in, distance_of_time_in_words(Time.now, pending.due_at.localtime))
             = '(' << l(pending.due_at.localtime, :format => :mmddhhss) << ')'
 
         - else


### PR DESCRIPTION
When I want create task on specific date on lead, task is created, but ActionView raise error.

<pre>
ActionView::Template::Error (expected numeric):
    35:             = l(pending.due_at.localtime, :format => :mmddhhss)
    36:           - else
    37:             = distance_of_time_in_words(Time.now, pending.due_at)
    38:             = '(' << l(pending.due_at.localtime, :format => :mmddhhss) << ')'
    39: 
    40:         - else
  app/views/tasks/create.js.rjs:32:in `block in _app_views_tasks_create_js_rjs___4415742061750010830_17258866880'
  app/views/tasks/create.js.rjs:1:in `_app_views_tasks_create_js_rjs___4415742061750010830_17258866880'
  app/controllers/tasks_controller.rb:87:in `create'
</pre>
