### PR TITLE
removed magic constant which doesnt allow for easy customization

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -18,7 +18,7 @@
 class CommentsController < ApplicationController
   before_filter :require_user
 
-  COMMENTABLE = %w(account_id campaign_id contact_id lead_id opportunity_id task_id).freeze
+
 
   # GET /comments
   # GET /comments.json
@@ -112,10 +112,10 @@ class CommentsController < ApplicationController
 private
 
   #----------------------------------------------------------------------------
-  def extract_commentable_name(params)
-    commentable = (params.keys & COMMENTABLE).first
-    commentable.sub('_id', '') if commentable
-  end
+    def extract_commentable_name(params)
+      commentable = params.keys.select{|x| /_id/ =~ x}.first
+      commentable.sub('_id', '') if commentable
+    end
 
   #----------------------------------------------------------------------------
   def update_commentable_session


### PR DESCRIPTION
there is no reason to have a hardcoded constant of what's commentable, it works fine because the only key passed in with _id appears to be the commentable
