### PR TITLE
for rails 2.3.9 / 1.9.3-p327 symbolise keys is required for mail to work...

### DIFF
--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -4,12 +4,12 @@ unless Rails.env.test?
   # Set SMTP settings if present.
   smtp_settings = Setting.smtp || {}
   if smtp_settings["address"].present?
-    Rails.application.config.action_mailer.delivery_method = :smtp
-    Rails.application.config.action_mailer.smtp_settings = smtp_settings
+    ActionMailer::Base.delivery_method = :smtp
+    ActionMailer::Base.smtp_settings = smtp_settings.symbolize_keys
   end
 end
 
 # Set default host for outgoing emails
 if Setting.host.present?
-  (Rails.application.config.action_mailer.default_url_options ||= {})[:host] = Setting.host
+  (ActionMailer::Base.default_url_options ||= {})[:host] = Setting.host
 end


### PR DESCRIPTION
.... otherwise keys are loaded as strings and fail with a connection error. Also needed to change to ActionMailer::Base for the settings to stick.
