### PR TITLE
inconsistency with entities/versions.js.erb which paginates at 20/page.

### DIFF
--- a/app/views/versions/_versions.html.haml
+++ b/app/views/versions/_versions.html.haml
@@ -5,7 +5,7 @@
   %div
     %div{ hidden_if(collapsed) }
       .list
-        - versions = Version.history(object).paginate(:page => 1, :per_page => 10)
+        - versions = Version.history(object).paginate(:page => 1, :per_page => 20)
         = render :partial => "versions/version", :collection => versions
 
       = will_paginate versions, :id => 'versions_pagination', :params => {:action => :versions}


### PR DESCRIPTION
There is an inconsistency in the per_page setting between here and entities/versions.js.erb (one is 10, the other 20)
