### PR TITLE
Fix email dropbox encoding issues by converting all emails to UTF8 charset

### DIFF
--- a/lib/fat_free_crm/mail_processor/base.rb
+++ b/lib/fat_free_crm/mail_processor/base.rb
@@ -207,18 +207,32 @@ module FatFreeCRM
           email.parts.map {|p| p.multipart? ? p.parts : p}.flatten
         else
           [email]
+          charset = email.charset
         end
 
         if text_part = parts.detect {|p| p.content_type.include?('text/plain')}
           text_body = text_part.body.to_s
-
+          charset = text_part.charset if email.multipart?
         else
           html_part = parts.detect {|p| p.content_type.include?('text/html')} || email
           text_body = Premailer.new(html_part.body.to_s, :with_html_string => true).to_plain_text
+          charset = html_part.charset if email.multipart?
         end
 
-        # Standardize newline
-        text_body.strip.gsub "\r\n", "\n"
+        # Convert to UTF8 and standardize newline
+        clean_invalid_utf8_bytes(text_body.strip.gsub("\r\n", "\n"), charset)
+      end
+
+      # Forces the encoding of the given string to UTF8 and replaces invalid characters. This is
+      # necessary as emails sometimes have invalid characters like MS "Smart Quotes."
+      def clean_invalid_utf8_bytes(text, src_encoding)
+        text.encode(
+          'UTF-8',
+          src_encoding,
+          invalid: :replace,
+          undef: :replace,
+          replace: ''
+        )
       end
 
     end


### PR DESCRIPTION
Hi,

Emails which contain character sets other than UTF8 can cause issues with the email dropbox feature. For instance, an email sent to me by a client had a "Microsoft Smart Quote" in it, which causes the following error:

```
[Tue, 23 Apr 2013 00:29:06 +0000] Dropbox: error processing email: #<ActiveRecord::StatementInvalid: PG::Error: ERROR:  invalid byte sequence for encoding "UTF8": 0x92
```

This pull request fixes this issue by converting all emails to UTF8 during processing. Since technically the RFC for email MIME specifies that each part can have its own encoding, it tries to look at the MIME type of the part that's being read, or falls back to the MIME type of the email itself.

This was difficult to test for me, so I have not included tests. But I have manually tested it against the offending email and it now is able to pass through the dropbox no problem. Let me know if you'd like to insist on a testing strategy.

Regards,
Daniel
