### PR TITLE
'undefined method current_database' causing ffcrm:setup rake task halt when using SQLite3

### DIFF
--- a/lib/tasks/ffcrm/setup.rake
+++ b/lib/tasks/ffcrm/setup.rake
@@ -8,7 +8,12 @@ namespace :ffcrm do
   desc "Prepare the database"
   task :setup => :environment do
     if ENV["PROCEED"] != 'true'
-      puts "\nFatFree CRM is about to run migrations on your database [#{ActiveRecord::Base.connection.current_database}]. Make sure you have a backup before proceeding.\n\n"
+      if ActiveRecord::Base.connection.class == ActiveRecord::ConnectionAdapters::SQLite3Adapter
+        database = ActiveRecord::Base.connection.instance_variable_get(:@config)[:database].split('/').last
+      else
+        database = ActiveRecord::Base.connection.current_database
+      end
+      puts "\nFatFree CRM is about to run migrations on your database [#{database}]. Make sure you have a backup before proceeding.\n\n"
       proceed = false
       loop do
         print "Continue [yes/no]: "


### PR DESCRIPTION
When running ffcrm:setup for the first time on an instance running SQLite3, rake task is unable to proceed, giving the following error:

undefined method `current_database' for #ActiveRecord::ConnectionAdapters::SQLite3Adapter:0x000001040e2630

SQLite3Adapter does not have a current_database method.

I've created a check to pull the sqlite3 database name using 'instance_variable_get' if it is detected that the adapter in use is indeed SQLite3Adapter.

Else, it will proceed as per normal and use 'current_database'.
