### PR TITLE
Fixed referencing error to FatFreeCRM::Version and rss/atom link exceptions on dashboard

### DIFF
--- a/app/views/home/index.atom.builder
+++ b/app/views/home/index.atom.builder
@@ -5,7 +5,7 @@ assets = controller.instance_variable_get("@#{items}")
 
 atom_feed do |feed|
   feed.title t(:activities)
-  feed.updated @activities.max { |a, b| a.updated_at <=> b.updated_at }.try(:updated_at)
+#  feed.updated @activities.max { |a, b| a.updated_at <=> b.updated_at }.try(:updated_at)
   feed.generator  "Fat Free CRM v#{FatFreeCRM::VERSION::STRING}"
   feed.author do |author|
     author.name  @current_user.full_name
@@ -13,11 +13,13 @@ atom_feed do |feed|
   end
 
   @activities.each do |activity|
-    feed.entry(activity, :url => '') do |entry|
-      entry.title activity_title(activity)
+    unless !activity.user.present?
+      feed.entry(activity, :url => '') do |entry|
+        entry.title activity_title(activity)
 
-      entry.author do |author|
-        author.name activity.user.full_name
+        entry.author do |author|
+          author.name activity.user.full_name
+        end
       end
     end
   end

--- a/app/views/home/index.rss.builder
+++ b/app/views/home/index.rss.builder
@@ -8,12 +8,14 @@ xml.rss :version => "2.0" do
     xml.title      t(:activities)
 
     @activities.each do |activity|
-      xml.item do
-        xml.author      activity.user.full_name
-        # xml.guid        activity.id
-        # xml.link        nil
-        xml.pubDate     activity.created_at.to_s(:rfc822)
-        xml.title       activity_title(activity)
+      unless !activity.user.present?
+        xml.item do
+          xml.author      activity.user.full_name
+          # xml.guid        activity.id
+          # xml.link        nil
+          xml.pubDate     activity.created_at.to_s(:rfc822)
+          xml.title       activity_title(activity)
+        end
       end
     end
   end


### PR DESCRIPTION
On the latest ffcrm master branch:

Bug 1:

To replicate:
1. In your logged in state in the dashboard, click on the "RSS" link at the bottom of the page.
2. You should see a:

```
uninitialized constant FatFreeCRM::Version exception.
```
1. Similarly, this occurs when clicking on the "ATOM" link.

Bug 2:

After the bug fix on Bug 1:
1. Click on the "RSS" link at the bottom of the dashboard page again.
2. You should see a:

``` ruby
    undefined method `full_name' for nil:NilClass

   10     @activities.each do |activity|
   11       xml.item do
   12         xml.author      activity.user.full_name
   13         # xml.guid        activity.id
   14         # xml.link        nil
   15         xml.pubDate     activity.created_at.to_s(:rfc822)
   16         xml.title       activity_title(activity)
   17       end
```
1. A similar error occurs when clicking on the "ATOM" link.

This is likely due to the RSS/ATOM view picking up activities that does not have a paper_trail 'whodunnit' attribute set. An example is when an activity is created when a user logs in and the system modifies the login_count.

An example of an activity that caused the original breakage of the above bugs:

``` bash
=> #<Version id: 17, item_type: User, item_id: 1, event: update, whodunnit: nil, object: --- nusername: davidcnemail: zhchua@gmail.comnfirst..., created_at: 2013-06-30 04:09:27, object_changes: --- !map:ActiveSupport::HashWithIndifferentAccess n..., related_id: nil, related_type: nil>
```

This pull request attempts to fix the uninitalized constant exception by pointing to the correct constant "FatFreeCRM::VERSION::STRING" and the full_name breakage by changing to ensure that there's a user in the first place. 

On a functional point, there is also no reason to display user login changes in rss/atom feeds.
