### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fat Free CRM [![TravisCI][travis-img-url]][travis-ci-url]
+# Fat Free CRM [![TravisCI][travis-img-url]][travis-ci-url]  [![Code Climate](https://codeclimate.com/github/fatfreecrm/fat_free_crm.png)](https://codeclimate.com/github/fatfreecrm/fat_free_crm)
 
 [travis-img-url]: https://secure.travis-ci.org/fatfreecrm/fat_free_crm.png?branch=master
 [travis-ci-url]: http://travis-ci.org/fatfreecrm/fat_free_crm


### PR DESCRIPTION
Hello,

Just wanted to drop you a note to let you know that someone added Fat Free CRM to Code Climate a while back.

I'm the guy who built Code Climate (automated quality metrics for Ruby) and it's completely free for OSS projects as a way to support them.

The code quality reports live here:

https://codeclimate.com/github/fatfreecrm/fat_free_crm

In case you want this information to be available to contributors, this quick PR just adds a dynamic badge to the README (similar to Travis) that displays the code quality GPA.

Let me know if you have any questions, or I can help with anything.

Hope you find Code Climate useful.

Best,

-Bryan
