### PR TITLE
rename attahcment to connected_object

### DIFF
--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -20,8 +20,8 @@ class EntitiesController < ApplicationController
   # Common attach handler for all core controllers.
   #----------------------------------------------------------------------------
   def attach
-    @attachment = params[:assets].classify.constantize.find(params[:asset_id])
-    @attached = entity.attach!(@attachment)
+    @connected_object = params[:assets].classify.constantize.find(params[:asset_id])
+    @attached = entity.attach!(@connected_object)
     entity.reload
 
     respond_with(entity)
@@ -30,8 +30,8 @@ class EntitiesController < ApplicationController
   # Common discard handler for all core controllers.
   #----------------------------------------------------------------------------
   def discard
-    @attachment = params[:attachment].constantize.find(params[:attachment_id])
-    entity.discard!(@attachment)
+    @connected_object = params[:connected_object].constantize.find(params[:connected_object_id])
+    entity.discard!(@connected_object)
     entity.reload
 
     respond_with(entity)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -132,7 +132,7 @@ module ApplicationHelper
     parent, parent_id = current_url.scan(%r|/(\w+)/(\d+)|).flatten
 
     link_to(t(:discard),
-      url_for(:controller => parent, :action => :discard, :id => parent_id, :attachment => object.class.name, :attachment_id => object.id),
+      url_for(:controller => parent, :action => :discard, :id => parent_id, :connected_object => object.class.name, :connected_object => object.id),
       :method  => :post,
       :remote  => true
     )

--- a/app/models/entities/account.rb
+++ b/app/models/entities/account.rb
@@ -26,6 +26,8 @@
 #
 
 class Account < ActiveRecord::Base
+  include Connectable
+
   belongs_to  :user
   belongs_to  :assignee, :class_name => "User", :foreign_key => :assigned_to
   has_many    :account_contacts, :dependent => :destroy
@@ -85,24 +87,6 @@ class Account < ActiveRecord::Base
     return "" unless self[:billing_address]
     location = self[:billing_address].strip.split("\n").last
     location.gsub(/(^|\s+)\d+(:?\s+|$)/, " ").strip if location
-  end
-
-  # Attach given attachment to the account if it hasn't been attached already.
-  #----------------------------------------------------------------------------
-  def attach!(attachment)
-    unless self.send("#{attachment.class.name.downcase}_ids").include?(attachment.id)
-      self.send(attachment.class.name.tableize) << attachment
-    end
-  end
-
-  # Discard given attachment from the account.
-  #----------------------------------------------------------------------------
-  def discard!(attachment)
-    if attachment.is_a?(Task)
-      attachment.update_attribute(:asset, nil)
-    else # Contacts, Opportunities
-      self.send(attachment.class.name.tableize).delete(attachment)
-    end
   end
 
   # Class methods.

--- a/app/models/entities/campaign.rb
+++ b/app/models/entities/campaign.rb
@@ -68,28 +68,28 @@ class Campaign < ActiveRecord::Base
   #----------------------------------------------------------------------------
   def self.per_page ; 20 ; end
 
-  # Attach given attachment to the campaign if it hasn't been attached already.
+  # Attach given connected object  to the campaign if it hasn't been attached already.
   #----------------------------------------------------------------------------
-  def attach!(attachment)
-    unless self.send("#{attachment.class.name.downcase}_ids").include?(attachment.id)
-      if attachment.is_a?(Task)
-        self.send(attachment.class.name.tableize) << attachment
+  def attach!(connected_object)
+    unless self.send("#{connected_object.class.name.downcase}_ids").include?(connected_object.id)
+      if connected_object.is_a?(Task)
+        self.send(connected_object.class.name.tableize) << connected_object
       else # Leads, Opportunities
-        attachment.update_attribute(:campaign, self)
-        attachment.send("increment_#{attachment.class.name.tableize}_count")
-        [ attachment ]
+        connected_object.update_attribute(:campaign, self)
+        connected_object.send("increment_#{connected_object.class.name.tableize}_count")
+        [ connected_object ]
       end
     end
   end
 
-  # Discard given attachment from the campaign.
+  # Discard given connected object from the campaign.
   #----------------------------------------------------------------------------
-  def discard!(attachment)
-    if attachment.is_a?(Task)
-      attachment.update_attribute(:asset, nil)
+  def discard!(connected_object)
+    if connected_object.is_a?(Task)
+      connected_object.update_attribute(:asset, nil)
     else # Leads, Opportunities
-      attachment.send("decrement_#{attachment.class.name.tableize}_count")
-      attachment.update_attribute(:campaign, nil)
+      connected_object.send("decrement_#{connected_object.class.name.tableize}_count")
+      connected_object.update_attribute(:campaign, nil)
     end
   end
 

--- a/app/models/entities/connectable.rb
+++ b/app/models/entities/connectable.rb
@@ -1,0 +1,21 @@
+module Connectable
+  extend ActiveSupport::Concern
+
+  # Attach given connected object if it hasn't been connected already.
+  #----------------------------------------------------------------------------
+  def attach!(connected_object)
+    unless self.send("#{connected_object.class.name.downcase}_ids").include?(connected_object.id)
+      self.send(connected_object.class.name.tableize) << connected_object
+    end
+  end
+
+  # Discard given connected object
+  #----------------------------------------------------------------------------
+  def discard!(connected_object)
+    if connected_object.is_a?(Task)
+      connected_object.update_attribute(:asset, nil)
+    else
+      self.send(connected_object.class.name.tableize).delete(connected_object)
+    end
+  end
+end

--- a/app/models/entities/contact.rb
+++ b/app/models/entities/contact.rb
@@ -37,6 +37,8 @@
 #
 
 class Contact < ActiveRecord::Base
+  include Connectable
+
   belongs_to  :user
   belongs_to  :lead
   belongs_to  :assignee, :class_name => "User", :foreign_key => :assigned_to
@@ -127,24 +129,6 @@ class Contact < ActiveRecord::Base
     self.access = params[:contact][:access] if params[:contact][:access]
     self.attributes = params[:contact]
     self.save
-  end
-
-  # Attach given attachment to the contact if it hasn't been attached already.
-  #----------------------------------------------------------------------------
-  def attach!(attachment)
-    unless self.send("#{attachment.class.name.downcase}_ids").include?(attachment.id)
-      self.send(attachment.class.name.tableize) << attachment
-    end
-  end
-
-  # Discard given attachment from the contact.
-  #----------------------------------------------------------------------------
-  def discard!(attachment)
-    if attachment.is_a?(Task)
-      attachment.update_attribute(:asset, nil)
-    else # Opportunities
-      self.send(attachment.class.name.tableize).delete(attachment)
-    end
   end
 
   # Class methods.

--- a/app/models/entities/opportunity.rb
+++ b/app/models/entities/opportunity.rb
@@ -26,6 +26,8 @@
 #
 
 class Opportunity < ActiveRecord::Base
+  include Connectable
+
   belongs_to  :user
   belongs_to  :campaign
   belongs_to  :assignee, :class_name => "User", :foreign_key => :assigned_to
@@ -134,24 +136,6 @@ class Opportunity < ActiveRecord::Base
     self.access = params[:opportunity][:access] if params[:opportunity][:access]
     self.attributes = params[:opportunity]
     self.save
-  end
-
-  # Attach given attachment to the opportunity if it hasn't been attached already.
-  #----------------------------------------------------------------------------
-  def attach!(attachment)
-    unless self.send("#{attachment.class.name.downcase}_ids").include?(attachment.id)
-      self.send(attachment.class.name.tableize) << attachment
-    end
-  end
-
-  # Discard given attachment from the opportunity.
-  #----------------------------------------------------------------------------
-  def discard!(attachment)
-    if attachment.is_a?(Task)
-      attachment.update_attribute(:asset, nil)
-    else # Contacts
-      self.send(attachment.class.name.tableize).delete(attachment)
-    end
   end
 
   # Class methods.

--- a/app/views/entities/attach.js.haml
+++ b/app/views/entities/attach.js.haml
@@ -2,17 +2,17 @@
 
 - if @attached
   - if partial == "task"
-    - if @attachment.completed?
+    - if @connected_object.completed?
       - view = "completed"
-    - elsif @attachment.my?(current_user)
+    - elsif @connected_object.my?(current_user)
       - view = "pending"
     - else
       - view = "assigned"
-    jQuery('#tasks').prepend('#{ j render(:partial => "tasks/#{view}", :collection => [ @attachment ], :locals => { :bucket => @attachment.computed_bucket }) }');
+    jQuery('#tasks').prepend('#{ j render(:partial => "tasks/#{view}", :collection => [ @connected_object ], :locals => { :bucket => @connected_object.computed_bucket }) }');
 
 
   - else
-    jQuery('##{h params[:assets]}').prepend('#{ j render(:partial => "#{params[:assets]}/#{partial}", :collection => [ @attachment ]) }');
+    jQuery('##{h params[:assets]}').prepend('#{ j render(:partial => "#{params[:assets]}/#{partial}", :collection => [ @connected_object ]) }');
     - if called_from_landing_page?(:accounts)
       = refresh_sidebar_for(:accounts, :show, :summary)
     - elsif called_from_landing_page?(:campaigns)

--- a/app/views/entities/discard.js.haml
+++ b/app/views/entities/discard.js.haml
@@ -1,4 +1,4 @@
-jQuery('##{dom_id(@attachment)}').slideUp(250);
+jQuery('##{dom_id(@connected_object)}').slideUp(250);
 
 - if called_from_landing_page?(:accounts)
   = refresh_sidebar_for(:accounts, :show, :summary)

--- a/spec/controllers/entities/accounts_controller_spec.rb
+++ b/spec/controllers/entities/accounts_controller_spec.rb
@@ -509,7 +509,7 @@ describe AccountsController do
     describe "tasks" do
       before do
         @model = FactoryGirl.create(:account)
-        @attachment = FactoryGirl.create(:task, :asset => nil)
+        @connected_object = FactoryGirl.create(:task, :asset => nil)
       end
       it_should_behave_like("attach")
     end
@@ -517,7 +517,7 @@ describe AccountsController do
     describe "contacts" do
       before do
         @model = FactoryGirl.create(:account)
-        @attachment = FactoryGirl.create(:contact, :account => nil)
+        @connected_object = FactoryGirl.create(:contact, :account => nil)
       end
       it_should_behave_like("attach")
     end
@@ -530,25 +530,25 @@ describe AccountsController do
     describe "tasks" do
       before do
         @model = FactoryGirl.create(:account)
-        @attachment = FactoryGirl.create(:task, :asset => @model)
+        @connected_object = FactoryGirl.create(:task, :asset => @model)
       end
       it_should_behave_like("discard")
     end
 
     describe "contacts" do
       before do
-        @attachment = FactoryGirl.create(:contact)
+        @connected_object = FactoryGirl.create(:contact)
         @model = FactoryGirl.create(:account)
-        @model.contacts << @attachment
+        @model.contacts << @connected_object
       end
       it_should_behave_like("discard")
     end
 
     describe "opportunities" do
       before do
-        @attachment = FactoryGirl.create(:opportunity)
+        @connected_object = FactoryGirl.create(:opportunity)
         @model = FactoryGirl.create(:account)
-        @model.opportunities << @attachment
+        @model.opportunities << @connected_object
       end
       # 'super from singleton method that is defined to multiple classes is not supported;'
       # TODO: Uncomment this when it is fixed in 1.9.3

--- a/spec/controllers/entities/campaigns_controller_spec.rb
+++ b/spec/controllers/entities/campaigns_controller_spec.rb
@@ -513,7 +513,7 @@ describe CampaignsController do
     describe "tasks" do
       before do
         @model = FactoryGirl.create(:campaign)
-        @attachment = FactoryGirl.create(:task, :asset => nil)
+        @connected_object = FactoryGirl.create(:task, :asset => nil)
       end
       it_should_behave_like("attach")
     end
@@ -521,7 +521,7 @@ describe CampaignsController do
     describe "leads" do
       before do
         @model = FactoryGirl.create(:campaign)
-        @attachment = FactoryGirl.create(:lead, :campaign => nil)
+        @connected_object = FactoryGirl.create(:lead, :campaign => nil)
       end
       it_should_behave_like("attach")
     end
@@ -529,7 +529,7 @@ describe CampaignsController do
     describe "opportunities" do
       before do
         @model = FactoryGirl.create(:campaign)
-        @attachment = FactoryGirl.create(:opportunity, :campaign => nil)
+        @connected_object = FactoryGirl.create(:opportunity, :campaign => nil)
       end
       it_should_behave_like("attach")
     end
@@ -542,7 +542,7 @@ describe CampaignsController do
     describe "tasks" do
       before do
         @model = FactoryGirl.create(:campaign)
-        @attachment = FactoryGirl.create(:task, :asset => nil)
+        @connected_object = FactoryGirl.create(:task, :asset => nil)
       end
       it_should_behave_like("attach")
     end
@@ -550,7 +550,7 @@ describe CampaignsController do
     describe "leads" do
       before do
         @model = FactoryGirl.create(:campaign)
-        @attachment = FactoryGirl.create(:lead, :campaign => nil)
+        @connected_object = FactoryGirl.create(:lead, :campaign => nil)
       end
       it_should_behave_like("attach")
     end
@@ -558,7 +558,7 @@ describe CampaignsController do
     describe "opportunities" do
       before do
         @model = FactoryGirl.create(:campaign)
-        @attachment = FactoryGirl.create(:opportunity, :campaign => nil)
+        @connected_object = FactoryGirl.create(:opportunity, :campaign => nil)
       end
       it_should_behave_like("attach")
     end
@@ -571,25 +571,25 @@ describe CampaignsController do
     describe "tasks" do
       before do
         @model = FactoryGirl.create(:campaign)
-        @attachment = FactoryGirl.create(:task, :asset => @model)
+        @connected_object = FactoryGirl.create(:task, :asset => @model)
       end
       it_should_behave_like("discard")
     end
 
     describe "leads" do
       before do
-        @attachment = FactoryGirl.create(:lead)
+        @connected_object = FactoryGirl.create(:lead)
         @model = FactoryGirl.create(:campaign)
-        @model.leads << @attachment
+        @model.leads << @connected_object
       end
       it_should_behave_like("discard")
     end
 
     describe "opportunities" do
       before do
-        @attachment = FactoryGirl.create(:opportunity)
+        @connected_object = FactoryGirl.create(:opportunity)
         @model = FactoryGirl.create(:campaign)
-        @model.opportunities << @attachment
+        @model.opportunities << @connected_object
       end
       it_should_behave_like("discard")
     end

--- a/spec/controllers/entities/contacts_controller_spec.rb
+++ b/spec/controllers/entities/contacts_controller_spec.rb
@@ -581,7 +581,7 @@ describe ContactsController do
     describe "tasks" do
       before do
         @model = FactoryGirl.create(:contact)
-        @attachment = FactoryGirl.create(:task, :asset => nil)
+        @connected_object = FactoryGirl.create(:task, :asset => nil)
       end
       it_should_behave_like("attach")
     end
@@ -589,7 +589,7 @@ describe ContactsController do
     describe "opportunities" do
       before do
         @model = FactoryGirl.create(:contact)
-        @attachment = FactoryGirl.create(:opportunity)
+        @connected_object = FactoryGirl.create(:opportunity)
       end
       it_should_behave_like("attach")
     end
@@ -602,7 +602,7 @@ describe ContactsController do
     describe "tasks" do
       before do
         @model = FactoryGirl.create(:contact)
-        @attachment = FactoryGirl.create(:task, :asset => nil)
+        @connected_object = FactoryGirl.create(:task, :asset => nil)
       end
       it_should_behave_like("attach")
     end
@@ -610,7 +610,7 @@ describe ContactsController do
     describe "opportunities" do
       before do
         @model = FactoryGirl.create(:contact)
-        @attachment = FactoryGirl.create(:opportunity)
+        @connected_object = FactoryGirl.create(:opportunity)
       end
       it_should_behave_like("attach")
     end
@@ -623,16 +623,16 @@ describe ContactsController do
     describe "tasks" do
       before do
         @model = FactoryGirl.create(:contact)
-        @attachment = FactoryGirl.create(:task, :asset => @model)
+        @connected_object = FactoryGirl.create(:task, :asset => @model)
       end
       it_should_behave_like("discard")
     end
 
     describe "opportunities" do
       before do
-        @attachment = FactoryGirl.create(:opportunity)
+        @connected_object = FactoryGirl.create(:opportunity)
         @model = FactoryGirl.create(:contact)
-        @model.opportunities << @attachment
+        @model.opportunities << @connected_object
       end
       it_should_behave_like("discard")
     end

--- a/spec/controllers/entities/leads_controller_spec.rb
+++ b/spec/controllers/entities/leads_controller_spec.rb
@@ -377,7 +377,7 @@ describe LeadsController do
         xhr :put, :create, :lead => { :first_name => "Billy", :last_name => "Bones"}, :campaign => @campaign.id
         assigns[:campaign].should == @campaign
       end
-      
+
       it "should add a new comment to the newly created lead when specified" do
         @lead = FactoryGirl.create(:lead)
         Lead.stub(:new).and_return(@lead)
@@ -928,7 +928,7 @@ describe LeadsController do
     describe "tasks" do
       before do
         @model = FactoryGirl.create(:lead)
-        @attachment = FactoryGirl.create(:task, :asset => nil)
+        @connected_object = FactoryGirl.create(:task, :asset => nil)
       end
       it_should_behave_like("attach")
     end
@@ -941,7 +941,7 @@ describe LeadsController do
     describe "tasks" do
       before do
         @model = FactoryGirl.create(:lead)
-        @attachment = FactoryGirl.create(:task, :asset => nil)
+        @connected_object = FactoryGirl.create(:task, :asset => nil)
       end
       it_should_behave_like("attach")
     end
@@ -952,9 +952,9 @@ describe LeadsController do
   #----------------------------------------------------------------------------
   describe "responding to POST discard" do
     before(:each) do
-      @attachment = FactoryGirl.create(:task, :assigned_to => current_user)
+      @connected_object = FactoryGirl.create(:task, :assigned_to => current_user)
       @model = FactoryGirl.create(:lead)
-      @model.tasks << @attachment
+      @model.tasks << @connected_object
     end
 
     it_should_behave_like("discard")

--- a/spec/controllers/entities/opportunities_controller_spec.rb
+++ b/spec/controllers/entities/opportunities_controller_spec.rb
@@ -818,7 +818,7 @@ describe OpportunitiesController do
     describe "tasks" do
       before do
         @model = FactoryGirl.create(:opportunity)
-        @attachment = FactoryGirl.create(:task, :asset => nil)
+        @connected_object = FactoryGirl.create(:task, :asset => nil)
       end
       it_should_behave_like("attach")
     end
@@ -826,7 +826,7 @@ describe OpportunitiesController do
     describe "contacts" do
       before do
         @model = FactoryGirl.create(:opportunity)
-        @attachment = FactoryGirl.create(:contact)
+        @connected_object = FactoryGirl.create(:contact)
       end
       it_should_behave_like("attach")
     end
@@ -839,16 +839,16 @@ describe OpportunitiesController do
     describe "tasks" do
       before do
         @model = FactoryGirl.create(:opportunity)
-        @attachment = FactoryGirl.create(:task, :asset => @model)
+        @connected_object = FactoryGirl.create(:task, :asset => @model)
       end
       it_should_behave_like("discard")
     end
 
     describe "contacts" do
       before do
-        @attachment = FactoryGirl.create(:contact)
+        @connected_object = FactoryGirl.create(:contact)
         @model = FactoryGirl.create(:opportunity)
-        @model.contacts << @attachment
+        @model.contacts << @connected_object
       end
       it_should_behave_like("discard")
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -40,7 +40,7 @@ describe ApplicationHelper do
 
     link = helper.link_to_discard(lead)
     link.should =~ %r|leads/#{lead.id}/discard|
-    link.should =~ %r|attachment=Lead&amp;attachment_id=#{lead.id}|
+    link.should =~ %r|connected_object=Lead&amp;connected_object_id=#{lead.id}|
   end
 
   describe "shown_on_landing_page?" do
@@ -68,19 +68,19 @@ describe ApplicationHelper do
       helper.shown_on_landing_page?.should == false
     end
   end
-  
+
   describe "current_view_name" do
-  
+
     before(:each) do
       @user = mock_model(User)
       helper.stub(:current_user).and_return(@user)
       controller.stub(:params).and_return({'action' => 'show', 'controller' => 'contacts'})
     end
-  
+
     it "should return the contact 'show' outline stored in the user preferences" do
       @user.should_receive(:pref).and_return({:contacts_show_view => 'long'})
       helper.current_view_name.should == 'long'
     end
-  
+
   end
 end

--- a/spec/models/entities/account_spec.rb
+++ b/spec/models/entities/account_spec.rb
@@ -52,7 +52,7 @@ describe Account do
       @account.attach!(@opportunity).should == nil
     end
 
-    it "should return non-empty list of attachments when attaching new asset" do
+    it "should return non-empty list of connected objects when attaching new asset" do
       @task = FactoryGirl.create(:task, :user => current_user)
       @contact = FactoryGirl.create(:contact)
       @opportunity = FactoryGirl.create(:opportunity)

--- a/spec/models/entities/campaign_spec.rb
+++ b/spec/models/entities/campaign_spec.rb
@@ -54,7 +54,7 @@ describe Campaign do
       @campaign.attach!(@opportunity).should == nil
     end
 
-    it "should return non-empty list of attachments when attaching new asset" do
+    it "should return non-empty list of connected objects when attaching new asset" do
       @task = FactoryGirl.create(:task, :user => current_user)
       @lead = FactoryGirl.create(:lead)
       @opportunity = FactoryGirl.create(:opportunity)

--- a/spec/models/entities/contact_spec.rb
+++ b/spec/models/entities/contact_spec.rb
@@ -104,7 +104,7 @@ describe Contact do
       @contact.attach!(@opportunity).should == nil
     end
 
-    it "should return non-empty list of attachments when attaching new asset" do
+    it "should return non-empty list of connected objects when attaching new asset" do
       @task = FactoryGirl.create(:task, :user => current_user)
       @opportunity = FactoryGirl.create(:opportunity)
 
@@ -161,17 +161,17 @@ describe Contact do
       end
     end
   end
-  
+
   describe "permissions" do
     it_should_behave_like Ability, Contact
   end
-  
+
   describe "text_search" do
-  
+
     before(:each) do
       @contact = FactoryGirl.create(:contact, :first_name => "Bob", :last_name => "Dillion", :email => 'bob_dillion@example.com', :phone => '+1 123 456 789')
     end
-    
+
     it "should search first_name" do
       Contact.text_search('Bob').should == [@contact]
     end
@@ -179,11 +179,11 @@ describe Contact do
     it "should search last_name" do
       Contact.text_search('Dillion').should == [@contact]
     end
-    
+
     it "should search whole name" do
       Contact.text_search('Bob Dillion').should == [@contact]
     end
-    
+
     it "should search whole name reversed" do
       Contact.text_search('Dillion Bob').should == [@contact]
     end
@@ -191,19 +191,19 @@ describe Contact do
     it "should search email" do
       Contact.text_search('example').should == [@contact]
     end
-    
+
     it "should search phone" do
       Contact.text_search('123').should == [@contact]
     end
-    
+
     it "should not break with a single quote" do
       contact2 = FactoryGirl.create(:contact, :first_name => "Shamus", :last_name => "O'Connell", :email => 'bob_dillion@example.com', :phone => '+1 123 456 789')
       Contact.text_search("O'Connell").should == [contact2]
     end
-    
+
     it "should not break on special characters" do
       Contact.text_search('@$%#^@!').should == []
     end
-  
+
   end
 end

--- a/spec/models/entities/opportunity_spec.rb
+++ b/spec/models/entities/opportunity_spec.rb
@@ -152,7 +152,7 @@ describe Opportunity do
       @opportunity.attach!(@contact).should == nil
     end
 
-    it "should return non-empty list of attachments when attaching new asset" do
+    it "should return non-empty list of connected objects when attaching new asset" do
       @task = FactoryGirl.create(:task, :user => current_user)
       @contact = FactoryGirl.create(:contact)
 

--- a/spec/shared/controllers.rb
+++ b/spec/shared/controllers.rb
@@ -33,27 +33,27 @@ end
 
 shared_examples "attach" do
   it "should attach existing asset to the parent asset of different type" do
-    xhr :put, :attach, :id => @model.id, :assets => @attachment.class.name.tableize, :asset_id => @attachment.id
-    @model.send(@attachment.class.name.tableize).should include(@attachment)
-    assigns[:attachment].should == @attachment
-    assigns[:attached].should == [ @attachment ]
-    if @model.is_a?(Campaign) && (@attachment.is_a?(Lead) || @attachment.is_a?(Opportunity))
-      assigns[:campaign].should == @attachment.reload.campaign
+    xhr :put, :attach, :id => @model.id, :assets => @connected_object.class.name.tableize, :asset_id => @connected_object.id
+    @model.send(@connected_object.class.name.tableize).should include(@connected_object)
+    assigns[:connected_object].should == @connected_object
+    assigns[:attached].should == [ @connected_object ]
+    if @model.is_a?(Campaign) && (@connected_object.is_a?(Lead) || @connected_object.is_a?(Opportunity))
+      assigns[:campaign].should == @connected_object.reload.campaign
     end
-    if @model.is_a?(Account) && @attachment.respond_to?(:account) # Skip Tasks...
-      assigns[:account].should == @attachment.reload.account
+    if @model.is_a?(Account) && @connected_object.respond_to?(:account) # Skip Tasks...
+      assigns[:account].should == @connected_object.reload.account
     end
     response.should render_template("entities/attach")
   end
 
   it "should not attach the asset that is already attached" do
-    if @model.is_a?(Campaign) && (@attachment.is_a?(Lead) || @attachment.is_a?(Opportunity))
-      @attachment.update_attribute(:campaign_id, @model.id)
+    if @model.is_a?(Campaign) && (@connected_object.is_a?(Lead) || @connected_object.is_a?(Opportunity))
+      @connected_object.update_attribute(:campaign_id, @model.id)
     else
-      @model.send(@attachment.class.name.tableize) << @attachment
+      @model.send(@connected_object.class.name.tableize) << @connected_object
     end
 
-    xhr :put, :attach, :id => @model.id, :assets => @attachment.class.name.tableize, :asset_id => @attachment.id
+    xhr :put, :attach, :id => @model.id, :assets => @connected_object.class.name.tableize, :asset_id => @connected_object.id
     assigns[:attached].should == nil
     response.should render_template("entities/attach")
   end
@@ -61,24 +61,24 @@ shared_examples "attach" do
   it "should display flash warning when the model is no longer available" do
     @model.destroy
 
-    xhr :put, :attach, :id => @model.id, :assets => @attachment.class.name.tableize, :asset_id => @attachment.id
+    xhr :put, :attach, :id => @model.id, :assets => @connected_object.class.name.tableize, :asset_id => @connected_object.id
     flash[:warning].should_not == nil
     response.body.should == "window.location.reload();"
   end
-  it "should display flash warning when the attachment is no longer available" do
-    @attachment.destroy
+  it "should display flash warning when the connected_object is no longer available" do
+    @connected_object.destroy
 
-    xhr :put, :attach, :id => @model.id, :assets => @attachment.class.name.tableize, :asset_id => @attachment.id
+    xhr :put, :attach, :id => @model.id, :assets => @connected_object.class.name.tableize, :asset_id => @connected_object.id
     flash[:warning].should_not == nil
     response.body.should == "window.location.reload();"
   end
 end
 
 shared_examples "discard" do
-  it "should discard the attachment without deleting it" do
-    xhr :post, :discard, :id => @model.id, :attachment => @attachment.class.name, :attachment_id => @attachment.id
-    assigns[:attachment].should == @attachment.reload                     # The attachment should still exist.
-    @model.reload.send("#{@attachment.class.name.tableize}").should == [] # But no longer associated with the model.
+  it "should discard the connected_object without deleting it" do
+    xhr :post, :discard, :id => @model.id, :connected_object => @connected_object.class.name, :connected_object_id => @connected_object.id
+    assigns[:connected_object].should == @connected_object.reload                     # The connected_object should still exist.
+    @model.reload.send("#{@connected_object.class.name.tableize}").should == [] # But no longer associated with the model.
     assigns[:account].should == @model if @model.is_a?(Account)
     assigns[:campaign].should == @model if @model.is_a?(Campaign)
 
@@ -88,15 +88,15 @@ shared_examples "discard" do
   it "should display flash warning when the model is no longer available" do
     @model.destroy
 
-    xhr :post, :discard, :id => @model.id, :attachment => @attachment.class.name, :attachment_id => @attachment.id
+    xhr :post, :discard, :id => @model.id, :connected_object => @connected_object.class.name, :connected_object_id => @connected_object.id
     flash[:warning].should_not == nil
     response.body.should == "window.location.reload();"
   end
 
-  it "should display flash warning when the attachment is no longer available" do
-    @attachment.destroy
+  it "should display flash warning when the connected_object is no longer available" do
+    @connected_object.destroy
 
-    xhr :post, :discard, :id => @model.id, :attachment => @attachment.class.name, :attachment_id => @attachment.id
+    xhr :post, :discard, :id => @model.id, :connected_object => @connected_object.class.name, :connected_object_id => @connected_object.id
     flash[:warning].should_not == nil
     response.body.should == "window.location.reload();"
   end


### PR DESCRIPTION
- to prevent name clash when adding paperclip attachment

- extract duplicate attach/discard methods in entities models into a
  module