### PR TITLE
Fixed field-display-bug in admin

### DIFF
--- a/app/views/admin/field_groups/_field_group.html.haml
+++ b/app/views/admin/field_groups/_field_group.html.haml
@@ -18,7 +18,7 @@
   .remote{ hidden.merge(:id => edit_form_id) }
 
   .list
-    %ul{ :id => dom_id(field_group, :fields), :class => 'fields', 'data-sortable' => sort_admin_fields_path(:field_group_id => field_group.id), 'data-sortable-connect-with' => '.fields', 'data-sortable-handle' => '.handle' }
+    %ul{ :id => dom_id(field_group, :fields), 'data-sortable' => sort_admin_fields_path(:field_group_id => field_group.id), 'data-sortable-connect-with' => '.fields', 'data-sortable-handle' => '.handle' }
       = render :partial => "admin/fields/field", :collection => field_group.fields.without_pairs
       %li.empty
         = t(:field_group_empty)


### PR DESCRIPTION
Suggestion for fixing #313
Excessive class ".fields" was set, which was referenced in coffee-script on tab-change. 
