### PR TITLE
Supply datepicker options in crm.flip_calendar

### DIFF
--- a/app/assets/javascripts/crm.js.coffee
+++ b/app/assets/javascripts/crm.js.coffee
@@ -164,7 +164,10 @@
       if value is "specific_time"
         $("#task_bucket").toggle() # Hide dropdown.
         $("#task_calendar").toggle() # Show editable date field.
-        $("#task_calendar").datepicker().focus() # Focus to invoke calendar popup.
+        $("#task_calendar").datepicker({
+          showOn: 'focus',
+          changeMonth: true,
+          dateFormat: 'yy-mm-dd'}).focus() # Focus to invoke calendar popup.
 
 
     #----------------------------------------------------------------------------


### PR DESCRIPTION
In datepicker.js.coffee we make sure that all datepicker inputs are invoked with the same options.  However, the datepicker on the task form is not enabled by default and is brought into existence separately by crm.flip_calendar.  This means it doesn't use the 'yy-mm-dd' format and so the wrong dates are set on the task (or completely incorrect dates blocking the creation / editting of the task entirely).

The solution is to use the same options for the datepicker call in crm.flip_calendar as we do in datepicker.js.coffee.

This fixes #328.
