### PR TITLE
Pagination bug fixed

### DIFF
--- a/app/views/admin/groups/index.html.haml
+++ b/app/views/admin/groups/index.html.haml
@@ -1,17 +1,17 @@
 = styles_for :group
 
 .title_tools
-  = link_to_inline(:create_group, new_admin_group_path, :text => t(:create_group))
+  = link_to_inline(:create_group, new_admin_group_path, text: t(:create_group))
 
 .title
   %span#create_group_title #{t :groups}
-  = image_tag("loading.gif", :size => :thumb, :id => "loading", :style => "display: none;")
+  = image_tag("loading.gif", size: :thumb, id: "loading", style: "display: none;")
 
 .remote#create_group{ hidden }
 
 %ul.list#groups
   - if @groups.any?
-    = render :partial => "group", :collection => @groups
+    = render partial: "group", collection: @groups
   - else
     = render "shared/empty"
 

--- a/app/views/admin/groups/index.html.haml
+++ b/app/views/admin/groups/index.html.haml
@@ -15,4 +15,4 @@
   - else
     = render "shared/empty"
 
-#paginate= render "shared/paginate"
+#paginate= render "shared/paginate_simple"

--- a/app/views/admin/groups/index.js.haml
+++ b/app/views/admin/groups/index.js.haml
@@ -1,2 +1,2 @@
-$('#groups').html('#{ j render(:partial => "admin/groups/group", :collection => @groups) }');
-$('#paginate').html('#{ j render(:partial => "shared/paginate_simple") }')
+$('#groups').html('#{ j render(partial: "admin/groups/group", collection: @groups) }');
+$('#paginate').html('#{ j render(partial: "shared/paginate_simple") }')

--- a/app/views/admin/groups/index.js.haml
+++ b/app/views/admin/groups/index.js.haml
@@ -1,2 +1,2 @@
 $('#groups').html('#{ j render(:partial => "admin/groups/group", :collection => @groups) }');
-$('#paginate').html('#{ j render(:partial => "shared/paginate") }')
+$('#paginate').html('#{ j render(:partial => "shared/paginate_simple") }')

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -1,13 +1,13 @@
 = styles_for :user
 
 .title_tools
-  = link_to_inline(:create_user, new_admin_user_path, :text => t(:create_user))
+  = link_to_inline(:create_user, new_admin_user_path, text: t(:create_user))
 
 .title
   %span#create_user_title #{t :users}
-  = image_tag("loading.gif", :size => :thumb, :id => "loading", :style => "display: none;")
+  = image_tag("loading.gif", size: :thumb, id: "loading", style: "display: none;")
 .remote#create_user{ hidden }
 
-.list#users= render :partial => "admin/users/user", :collection => @users
+.list#users= render partial: "admin/users/user", collection: @users
 #paginate= render "shared/paginate_simple"
 #export= render "shared/export"

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -9,5 +9,5 @@
 .remote#create_user{ hidden }
 
 .list#users= render :partial => "admin/users/user", :collection => @users
-#paginate= render "shared/paginate"
+#paginate= render "shared/paginate_simple"
 #export= render "shared/export"

--- a/app/views/admin/users/index.js.haml
+++ b/app/views/admin/users/index.js.haml
@@ -1,2 +1,2 @@
-$('#users').html('#{ j render(:partial => "admin/users/user", :collection => @users) }');
-$('#paginate').html('#{ j render(:partial => "shared/paginate_simple") }')
+$('#users').html('#{ j render(partial: "admin/users/user", collection: @users) }');
+$('#paginate').html('#{ j render(partial: "shared/paginate_simple") }')

--- a/app/views/admin/users/index.js.haml
+++ b/app/views/admin/users/index.js.haml
@@ -1,2 +1,2 @@
 $('#users').html('#{ j render(:partial => "admin/users/user", :collection => @users) }');
-$('#paginate').html('#{ j render(:partial => "shared/paginate") }')
+$('#paginate').html('#{ j render(:partial => "shared/paginate_simple") }')

--- a/app/views/home/index.js.haml
+++ b/app/views/home/index.js.haml
@@ -1,7 +1,7 @@
 - unless @activities.blank?
-  $('#activities').html('#{ j render(:partial => "activity", :collection => @activities) }');
+  $('#activities').html('#{ j render(partial: "activity", collection: @activities) }');
 - else
   $('#activities').html('#{ j t(:no_activity_records) }');
 
--# $('#paginate').html('#{ j render(:partial => "shared/paginate_simple") }');
-$('#export').html('#{ j render(:partial => "shared/export") }');
+-# $('#paginate').html('#{ j render(partial: "shared/paginate_simple") }');
+$('#export').html('#{ j render(partial: "shared/export") }');

--- a/app/views/home/index.js.haml
+++ b/app/views/home/index.js.haml
@@ -3,5 +3,5 @@
 - else
   $('#activities').html('#{ j t(:no_activity_records) }');
 
--# $('#paginate').html('#{ j render(:partial => "shared/paginate") }');
+-# $('#paginate').html('#{ j render(:partial => "shared/paginate_simple") }');
 $('#export').html('#{ j render(:partial => "shared/export") }');

--- a/app/views/shared/_paginate_simple.haml
+++ b/app/views/shared/_paginate_simple.haml
@@ -1,2 +1,4 @@
 = image_tag("loading.gif", size: 'thumb', class: "spinner", style: "display: none;")
 = paginate
+
+  

--- a/spec/views/admin/users/index.haml_spec.rb
+++ b/spec/views/admin/users/index.haml_spec.rb
@@ -7,15 +7,15 @@ require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper')
 
 describe "/admin/users/index" do
   before do
-    login_and_assign(:admin => true)
+    login_and_assign(admin: true)
   end
 
   it "renders a list of users" do
     assign(:users, [ FactoryGirl.create(:user) ].paginate)
 
     render
-    view.should render_template(:partial => "_user")
-    view.should render_template(:partial => "shared/_paginate_simple")
+    view.should render_template(partial: "_user")
+    view.should render_template(partial: "shared/_paginate_simple")
   end
 end
 

--- a/spec/views/admin/users/index.haml_spec.rb
+++ b/spec/views/admin/users/index.haml_spec.rb
@@ -15,7 +15,7 @@ describe "/admin/users/index" do
 
     render
     view.should render_template(:partial => "_user")
-    view.should render_template(:partial => "shared/_paginate")
+    view.should render_template(:partial => "shared/_paginate_simple")
   end
 end
 


### PR DESCRIPTION
The pagiantion wasn't working in the /admin Users tab. I am not sure why, but the problem seemed to be that the view  app/views/shared/_paginate.haml contained a call to a shared method also called paginate. Renaming the view and all of its references to  _paginate_simple.haml has solved the problem.

Issue #348 