### PR TITLE
Made engine advertise factories for future usage in parent app

### DIFF
--- a/lib/fat_free_crm/engine.rb
+++ b/lib/fat_free_crm/engine.rb
@@ -9,5 +9,8 @@ module FatFreeCRM
                              Dir[root.join("app/controllers/entities")]
     config.active_record.observers = [:lead_observer, :opportunity_observer,
                                       :task_observer, :entity_observer]
+    initializer "model_core.factories", :after => "factory_girl.set_factory_paths" do
+      FactoryGirl.definition_file_paths << File.expand_path('../../../spec/factories', __FILE__) if defined?(FactoryGirl)
+    end
   end
 end


### PR DESCRIPTION
When used as an engine, it's good to expose engine's factories so they can be used in rails app tests.

More here:
https://github.com/cryo28/factory_girl_rails/commit/191ce5e47e495d2dd7a6b7a8247163e4200cc364