### PR TITLE
Fix params call for user in password reset

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -35,7 +35,7 @@ class PasswordsController < ApplicationController
     if empty_password?
       flash[:notice] = t(:msg_enter_new_password)
       render :edit
-    elsif @user.update_attributes(params[:user])
+    elsif @user.update_attributes(params.require(:user).permit(:password, :password_confirmation))
       flash[:notice] = t(:msg_password_updated)
       redirect_to profile_url
     else


### PR DESCRIPTION
The password reset was throwing an AccessForbidden Error due to the Rails 4 strong params changes. This change fixes it.