### PR TITLE
Add bits required for API access

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,8 +8,10 @@ class ApplicationController < ActionController::Base
 
   before_action :set_context
   before_action :clear_setting_cache
+  before_action :cors_preflight_check
   before_action "hook(:app_before_filter, self)"
   after_action "hook(:app_after_filter,  self)"
+  after_action :cors_set_access_control_headers
 
   helper_method :current_user_session, :current_user, :can_signup?
   helper_method :called_from_index_page?, :called_from_landing_page?
@@ -251,6 +253,24 @@ class ApplicationController < ActionController::Base
             (respond_to?(:index) && action_name != 'index') ? { action: 'index' } : root_url
           else
             login_url
+    end
+  end
+
+  def cors_set_access_control_headers
+    headers['Access-Control-Allow-Origin'] = '*'
+    headers['Access-Control-Allow-Methods'] = 'POST, GET, PUT, DELETE, OPTIONS'
+    headers['Access-Control-Allow-Headers'] = 'Origin, Content-Type, Accept, Authorization, Token'
+    headers['Access-Control-Max-Age'] = "1728000"
+  end
+
+  def cors_preflight_check
+    if request.method == 'OPTIONS'
+      headers['Access-Control-Allow-Origin'] = '*'
+      headers['Access-Control-Allow-Methods'] = 'POST, GET, PUT, DELETE, OPTIONS'
+      headers['Access-Control-Allow-Headers'] = 'X-Requested-With, X-Prototype-Version, Token'
+      headers['Access-Control-Max-Age'] = '1728000'
+
+      render :text => '', :content_type => 'text/plain'
     end
   end
 end

--- a/app/models/users/authentication.rb
+++ b/app/models/users/authentication.rb
@@ -6,6 +6,7 @@
 class Authentication < Authlogic::Session::Base # NOTE: This is not ActiveRecord model.
   authenticate_with User
   after_save :check_if_suspended
+  single_access_allowed_request_types :any
 
   def to_key
     id ? id : nil


### PR DESCRIPTION
This allows you to access the API remotely if you know your single use token.  For an example application using the API, see https://github.com/knewter/fat_free_ionic