### PR TITLE
[#447] Convert CamelCase strings to snake_case with String#snakecase

### DIFF
--- a/lib/fat_free_crm/core_ext/string.rb
+++ b/lib/fat_free_crm/core_ext/string.rb
@@ -23,7 +23,15 @@ class String
   end
 
   def snakecase
-    strip.downcase.gsub(/[\s\/]+/, "_")
+    str = dup
+    str.gsub!(/::/, '/')
+    str.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+    str.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+    str.gsub!(/\s+/, "_")
+    str.tr! ".", "_"
+    str.tr! "-", "_"
+    str.downcase!
+    str
   end
 
   def true?


### PR DESCRIPTION
Add ability to convert CamelCase strings to snake_case with String#snakecase.
Issue #447.