### PR TITLE
Update URL for advanced search

### DIFF
--- a/app/assets/javascripts/search.js.coffee
+++ b/app/assets/javascripts/search.js.coffee
@@ -41,9 +41,15 @@
           $('#filters').prop('disabled', false) # Enable filters panel (if present)
 
         when 'advanced_search'
-          $("#advanced_search form input:submit").click()
+          $('#advanced_search form input:submit').submit()
           $('#filters').prop('disabled', true) # Disable filters panel (if present)
 
+      return
+
+    # Update URL in browser #434
+    $(document).on 'click', '#advanced_search form input:submit', ->
+      # history.pushState(stateObj, title, url)
+      history.pushState("","",window.location.pathname + '?' + $('form.ransack_search').serialize())
       return
 
 ) jQuery


### PR DESCRIPTION
Issue #434 

Updates browser URL through History API.

https://developer.mozilla.org/en-US/docs/Web/API/History_API

Line 44 is changed to submit() to avoid the click() update.