### PR TITLE
Adding missing jQuery UI i18n

### DIFF
--- a/vendor/assets/javascripts/jquery_timeago/index.js
+++ b/vendor/assets/javascripts/jquery_timeago/index.js
@@ -9,6 +9,7 @@
 //= require jquery_timeago/jquery.timeago.it
 //= require jquery_timeago/jquery.timeago.ja
 //= require jquery_timeago/jquery.timeago.js
+//= require jquery_timeago/jquery.timeago.nl.js
 //= require jquery_timeago/jquery.timeago.pl.js
 //= require jquery_timeago/jquery.timeago.pt-BR
 //= require jquery_timeago/jquery.timeago.ru.js

--- a/vendor/assets/javascripts/jquery_timeago/index.js
+++ b/vendor/assets/javascripts/jquery_timeago/index.js
@@ -4,6 +4,7 @@
 //= require jquery_timeago/jquery.timeago.en-GB
 //= require jquery_timeago/jquery.timeago.en-US
 //= require jquery_timeago/jquery.timeago.es
+//= require jquery_timeago/jquery.timeago.es-CL
 //= require jquery_timeago/jquery.timeago.fr-CA
 //= require jquery_timeago/jquery.timeago.fr
 //= require jquery_timeago/jquery.timeago.it

--- a/vendor/assets/javascripts/jquery_timeago/jquery.timeago.es-CL.js
+++ b/vendor/assets/javascripts/jquery_timeago/jquery.timeago.es-CL.js
@@ -1,0 +1,18 @@
+// Spanish
+jQuery.timeago.settings.locales['es-CL'] = {
+   prefixAgo: "hace",
+   prefixFromNow: "dentro de",
+   suffixAgo: "",
+   suffixFromNow: "",
+   seconds: "menos de un minuto",
+   minute: "un minuto",
+   minutes: "unos %d minutos",
+   hour: "una hora",
+   hours: "%d horas",
+   day: "un día",
+   days: "%d días",
+   month: "un mes",
+   months: "%d meses",
+   year: "un año",
+   years: "%d años"
+};

--- a/vendor/assets/javascripts/jquery_timeago/jquery.timeago.nl.js
+++ b/vendor/assets/javascripts/jquery_timeago/jquery.timeago.nl.js
@@ -1,4 +1,4 @@
-// Italian
+// Dutch
 jQuery.timeago.settings.locales['nl'] = {
   prefixAgo: null,
   prefixFromNow: "over",

--- a/vendor/assets/javascripts/jquery_timeago/jquery.timeago.nl.js
+++ b/vendor/assets/javascripts/jquery_timeago/jquery.timeago.nl.js
@@ -1,0 +1,20 @@
+// Italian
+jQuery.timeago.settings.locales['nl'] = {
+  prefixAgo: null,
+  prefixFromNow: "over",
+  suffixAgo: "geleden",
+  suffixFromNow: null,
+  seconds: "minder dan een minuut",
+  minute: "ongeveer een minuut",
+  minutes: "%d minuten",
+  hour: "ongeveer een uur",
+  hours: "ongeveer %d uur",
+  day: "een dag",
+  days: "%d dagen",
+  month: "ongeveer een maand",
+  months: "%d maanden",
+  year: "ongeveer een jaar",
+  years: "%d jaar",
+  wordSeparator: " ",
+  numbers: []
+};

--- a/vendor/assets/javascripts/jquery_ui_datepicker/jquery-ui-timepicker-es-CL.js
+++ b/vendor/assets/javascripts/jquery_ui_datepicker/jquery-ui-timepicker-es-CL.js
@@ -1,0 +1,20 @@
+/* Spanish translation for the jQuery Timepicker Addon */
+/* Written by Ianaré Sévi */
+(function($) {
+	$.timepicker.regional['es-CL'] = {
+		timeOnlyTitle: 'Elegir una hora',
+		timeText: 'Hora',
+		hourText: 'Horas',
+		minuteText: 'Minutos',
+		secondText: 'Segundos',
+		millisecText: 'Milisegundos',
+		timezoneText: 'Huso horario',
+		currentText: 'Ahora',
+		closeText: 'Cerrar',
+		timeFormat: 'hh:mm',
+		amNames: ['a.m.', 'AM', 'A'],
+		pmNames: ['p.m.', 'PM', 'P'],
+		ampm: false
+	};
+	$.timepicker.setDefaults($.timepicker.regional['es-CL']);
+})(jQuery);

--- a/vendor/assets/javascripts/jquery_ui_datepicker/jquery.ui.datepicker-es-CL.js
+++ b/vendor/assets/javascripts/jquery_ui_datepicker/jquery.ui.datepicker-es-CL.js
@@ -1,0 +1,23 @@
+/* Inicialización en español para la extensión 'UI date picker' para jQuery. */
+/* Traducido por Vester (xvester@gmail.com). */
+jQuery(function($){
+	$.datepicker.regional['es-CL'] = {
+		closeText: 'Cerrar',
+		prevText: '&#x3c;Ant',
+		nextText: 'Sig&#x3e;',
+		currentText: 'Hoy',
+		monthNames: ['Enero','Febrero','Marzo','Abril','Mayo','Junio',
+		'Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'],
+		monthNamesShort: ['Ene','Feb','Mar','Abr','May','Jun',
+		'Jul','Ago','Sep','Oct','Nov','Dic'],
+		dayNames: ['Domingo','Lunes','Martes','Mi&eacute;rcoles','Jueves','Viernes','S&aacute;bado'],
+		dayNamesShort: ['Dom','Lun','Mar','Mi&eacute;','Juv','Vie','S&aacute;b'],
+		dayNamesMin: ['Do','Lu','Ma','Mi','Ju','Vi','S&aacute;'],
+		weekHeader: 'Sm',
+		dateFormat: 'dd/mm/yy',
+		firstDay: 1,
+		isRTL: false,
+		showMonthAfterYear: false,
+		yearSuffix: ''};
+	$.datepicker.setDefaults($.datepicker.regional['es-CL']);
+});

--- a/vendor/assets/javascripts/jquery_ui_datepicker/jquery.ui.datepicker-nl.js
+++ b/vendor/assets/javascripts/jquery_ui_datepicker/jquery.ui.datepicker-nl.js
@@ -1,0 +1,21 @@
+jQuery(function($){
+  $.datepicker.regional['nl'] = {
+    closeText: 'Sluiten',
+    prevText: '←',
+    nextText: '→',
+    currentText: 'Vandaag',
+    monthNames: ['januari', 'februari', 'maart', 'april', 'mei', 'juni',
+    'juli', 'augustus', 'september', 'oktober', 'november', 'december'],
+    monthNamesShort: ['jan', 'feb', 'mrt', 'apr', 'mei', 'jun',
+    'jul', 'aug', 'sep', 'okt', 'nov', 'dec'],
+    dayNames: ['zondag', 'maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag', 'zaterdag'],
+    dayNamesShort: ['zon', 'maa', 'din', 'woe', 'don', 'vri', 'zat'],
+    dayNamesMin: ['zo', 'ma', 'di', 'wo', 'do', 'vr', 'za'],
+    weekHeader: 'Wk',
+    dateFormat: 'dd-mm-yy',
+    firstDay: 1,
+    isRTL: false,
+    showMonthAfterYear: false,
+    yearSuffix: ''};
+  $.datepicker.setDefaults($.datepicker.regional['nl']);
+});


### PR DESCRIPTION
For #469, #477,  jQuery UI i18n is missing.

NL is added.
es-CL is duplicated from es.