### PR TITLE
Fix nl translation files overriding en-US for ransack.

### DIFF
--- a/config/locales/nl_ransack.yml
+++ b/config/locales/nl_ransack.yml
@@ -1,5 +1,5 @@
 ---
-en-US:
+nl:
   ransack:
     search: zoeken
     predicate: predicate


### PR DESCRIPTION
From PR #477 

nl ransack i18n was using en-US LCID.