### PR TITLE
Update libv8 gem version from 3.16.14.13 to 3.16.14.15

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
       railties (>= 3.2.16)
     json (1.8.3)
     kgio (2.10.0)
-    libv8 (3.16.14.13)
+    libv8 (3.16.14.15)
     listen (3.0.5)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)


### PR DESCRIPTION
Hello, for install in freebsd, i must update libv8 to 3.16.14.15
