### PR TITLE
Replaced git shellout by Globby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,6 @@ GEM
     formatador (0.2.5)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
-    globby (0.1.2)
     guard (2.13.0)
       formatador (>= 0.2.4)
       listen (>= 2.7, <= 4.0)
@@ -383,7 +382,6 @@ DEPENDENCIES
   factory_girl_rails
   ffaker (>= 2)
   font-awesome-rails
-  globby
   guard
   guard-rails
   guard-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
     formatador (0.2.5)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
+    globby (0.1.2)
     guard (2.13.0)
       formatador (>= 0.2.4)
       listen (>= 2.7, <= 4.0)
@@ -382,6 +383,7 @@ DEPENDENCIES
   factory_girl_rails
   ffaker (>= 2)
   font-awesome-rails
+  globby
   guard
   guard-rails
   guard-rspec

--- a/fat_free_crm.gemspec
+++ b/fat_free_crm.gemspec
@@ -2,6 +2,11 @@
 $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'fat_free_crm/version'
 
+require 'globby'
+rules = File.read('.gitignore').split("\n")
+rules << '.git'
+files = Globby.reject(rules)
+
 Gem::Specification.new do |gem|
   gem.name = 'fat_free_crm'
   gem.authors = ['Michael Dvorkin', 'Ben Tillman', 'Nathan Broadbent', 'Stephen Kenworthy']
@@ -9,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.description = 'An open source, Ruby on Rails customer relationship management platform'
   gem.homepage = 'http://fatfreecrm.com'
   gem.email = ['mike@fatfreecrm.com', 'nathan@fatfreecrm.com', 'warp@fatfreecrm.com', 'steveyken@gmail.com']
-  gem.files = `git ls-files`.split("\n")
+  gem.files = files
   gem.version = FatFreeCRM::VERSION::STRING
   gem.required_ruby_version = '>= 2.0.0'
   gem.license = 'MIT'
@@ -48,6 +53,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rails_autolink'
   gem.add_dependency 'coffee-script-source', '~>1.8.0' # pegged until https://github.com/jashkenas/coffeescript/issues/3829 is resolved
   gem.add_dependency 'country_select'
+  gem.add_dependency 'globby'
 
   # FatFreeCRM has released it's own versions of the following gems:
   #-----------------------------------------------------------------

--- a/fat_free_crm.gemspec
+++ b/fat_free_crm.gemspec
@@ -1,11 +1,12 @@
 # -*- encoding: utf-8 -*-
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
-require 'fat_free_crm/version'
-
+$LOAD_PATH.push File.expand_path('../vendor/gems/globby-0.1.2/lib', __FILE__)
 require 'globby'
-rules = File.read('.gitignore').split("\n")
+rules = File.read("#{File.expand_path('..', __FILE__)}/.gitignore").split("\n")
 rules << '.git'
 files = Globby.reject(rules)
+
+$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+require 'fat_free_crm/version'
 
 Gem::Specification.new do |gem|
   gem.name = 'fat_free_crm'
@@ -53,7 +54,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rails_autolink'
   gem.add_dependency 'coffee-script-source', '~>1.8.0' # pegged until https://github.com/jashkenas/coffeescript/issues/3829 is resolved
   gem.add_dependency 'country_select'
-  gem.add_dependency 'globby'
 
   # FatFreeCRM has released it's own versions of the following gems:
   #-----------------------------------------------------------------

--- a/vendor/gems/globby-0.1.2/LICENSE.txt
+++ b/vendor/gems/globby-0.1.2/LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2014 Jon Jensen
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/gems/globby-0.1.2/README.md
+++ b/vendor/gems/globby-0.1.2/README.md
@@ -1,0 +1,65 @@
+# globby
+
+[<img src="https://travis-ci.org/jenseng/globby.svg" />](http://travis-ci.org/jenseng/globby)
+
+globby is a [`.gitignore`](http://www.kernel.org/pub/software/scm/git/docs/gitignore.html)-style
+file globber for ruby.
+
+## Installation
+
+Put `gem 'globby'` in your Gemfile.
+
+## Usage
+
+    # all files matched by the rules
+    Globby.select(rules)
+
+    # all other files
+    Globby.reject(rules)
+
+    # ooh chaining!
+    Globby.select(rules).reject(other_rules)
+
+### An example:
+
+     > rules = File.read('.gitignore').split(/\n/)
+    -> ["Gemfile.lock", "doc", "*.gem"]
+
+     > pp Globby.select(rules)
+    ["Gemfile.lock",
+     "doc/Foreigner.html",
+     "doc/Foreigner/Adapter.html",
+     "doc/Gemfile.html",
+     "doc/Immigrant.html",
+     ...
+     "immigrant-0.1.3.gem",
+     "immigrant-0.1.4.gem"]
+    => nil
+
+## Why on earth would I ever use this?
+
+* You're curious what is getting `.gitignore`'d and/or you want to do something
+  with those files.
+* You're writing a library/tool that will have its own list of ignored/tracked
+  files. My use case is for an I18n library that extracts strings from ruby
+  files... I need to provide users a nice configurable way to blacklist given
+  files/directories/patterns.
+
+## Compatibility Notes
+
+globby is compatible with `.gitignore` rules; it respects negated patterns, and
+ignores comments or empty patterns. That said, it supports some things that may
+or may not work in your version of git. These platform-dependent `.gitignore`
+behaviors are platform independent in globby and can always be used:
+
+ * Recursive wildcards à la ant/zsh/ruby. `**` matches directories recursively.
+ * [glob(7)](https://www.kernel.org/doc/man-pages/online/pages/man7/glob.7.html)-style
+   bracket expressions, i.e. character classes, ranges, complementation, named
+   character classes, collating symbols and equivalence class expressions. Note
+   that the syntax for some of these is slightly different than what you would
+   find in regular expressions. Refer to [the documentation](https://www.kernel.org/doc/man-pages/online/pages/man7/glob.7.html)
+   for more info.
+
+## License
+
+Copyright (c) 2013-2016 Jon Jensen, released under the MIT license

--- a/vendor/gems/globby-0.1.2/Rakefile
+++ b/vendor/gems/globby-0.1.2/Rakefile
@@ -1,0 +1,9 @@
+require 'rake'
+
+require 'rspec/core'
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.pattern = FileList['spec/**/*_spec.rb']
+end
+
+task :default => :spec

--- a/vendor/gems/globby-0.1.2/lib/globby.rb
+++ b/vendor/gems/globby-0.1.2/lib/globby.rb
@@ -1,0 +1,47 @@
+require 'set'
+require 'globby/glob'
+require 'globby/globject'
+require 'globby/result'
+
+module Globby
+  class << self
+    def select(patterns, source = GlObject.all)
+      result = GlObject.new
+      evaluate_patterns(patterns, source, result)
+
+      if result.dirs && result.dirs.size > 0
+        # now go merge/subtract files under directories
+        dir_patterns = result.dirs.map{ |dir| "/#{dir}**" }
+        evaluate_patterns(dir_patterns, GlObject.new(source.files), result)
+      end
+
+      Result.new result.files, source.dirs
+    end
+
+    def reject(patterns, source = GlObject.all)
+      Result.new(source.files - select(patterns, source), source.dirs)
+    end
+
+   private
+
+    def evaluate_patterns(patterns, source, result)
+      patterns.each do |pattern|
+        next unless pattern =~ /\A[^#]/
+        evaluate_pattern pattern, source, result
+      end
+    end
+
+    def evaluate_pattern(pattern, source, result)
+      glob = Globby::Glob.new(pattern)
+      method, candidates = glob.inverse? ?
+        [:subtract, result] :
+        [:merge, source]
+
+      dir_matches = glob.match(candidates.dirs)
+      file_matches = []
+      file_matches = glob.match(candidates.files) unless glob.directory? || glob.exact_match? && !dir_matches.empty?
+      result.dirs.send method, dir_matches unless dir_matches.empty?
+      result.files.send method, file_matches unless file_matches.empty?
+    end
+  end
+end

--- a/vendor/gems/globby-0.1.2/lib/globby/glob.rb
+++ b/vendor/gems/globby-0.1.2/lib/globby/glob.rb
@@ -1,0 +1,90 @@
+module Globby
+  class Glob
+    def initialize(pattern)
+      pattern = pattern.dup
+      @inverse = pattern.sub!(/\A!/, '')
+      # remove meaningless wildcards
+      pattern.sub!(/\A\/?(\*\*\/)+/, '')
+      pattern.sub!(/(\/\*\*)+\/\*\z/, '/**')
+      @pattern = pattern
+    end
+
+    def match(files)
+      return [] unless files
+      files.grep(to_regexp)
+    end
+
+    def inverse?
+      @inverse
+    end
+
+    def directory?
+      @pattern =~ /\/\z/
+    end
+
+    def exact_match?
+      @pattern =~ /\A\// && @pattern !~ /[\*\?]/
+    end
+
+    # see https://www.kernel.org/doc/man-pages/online/pages/man7/glob.7.html
+    GLOB_BRACKET_EXPR = /
+      \[ # brackets
+        !? # (maybe) negation
+        \]? # (maybe) right bracket
+        (?: # one or more:
+          \[[^\/\]]+\] # named character class, collating symbol or equivalence class
+          | [^\/\]] # non-right bracket character (could be part of a range)
+        )+
+      \]/x
+    GLOB_ESCAPED_CHAR = /\\./
+    GLOB_RECURSIVE_WILDCARD = /\/\*\*(?:\/|\z)/
+    GLOB_WILDCARD = /[\?\*]/
+
+    GLOB_TOKENIZER = /(
+      #{GLOB_BRACKET_EXPR} |
+      #{GLOB_ESCAPED_CHAR} |
+      #{GLOB_RECURSIVE_WILDCARD}
+    )/x
+
+    def to_regexp
+      parts = @pattern.split(GLOB_TOKENIZER) - [""]
+
+      result = parts.first.sub!(/\A\//, '') ? '\A' : '(\A|/)'
+      parts.each do |part|
+        result << part_to_regexp(part)
+      end
+      if result[-1, 1] == '/'
+        result << '\z'
+      elsif result[-2, 2] == '.*'
+        result.slice!(-2, 2)
+      else
+        result << '\/?\z'
+      end
+      Regexp.new result
+    end
+
+   private
+
+    def part_to_regexp(part)
+      case part
+      when GLOB_BRACKET_EXPR
+        # fix negation and escape right bracket
+        part.sub(/\A\[!/, '[^').sub(/\A(\[\^?)\]/, '\1\]')
+      when GLOB_ESCAPED_CHAR
+        part
+      when GLOB_RECURSIVE_WILDCARD
+        part[-1, 1] == '/' ? "/(.+/)?" : "/.*"
+      when GLOB_WILDCARD
+        (part.split(/(#{GLOB_WILDCARD})/) - [""]).inject("") do |result, p|
+          result << case p
+            when '?'; '[^/]'
+            when '*'; '[^/]' + (result.end_with?("/") ? '+' : '*')
+            else Regexp.escape(p)
+          end
+        end
+      else # literal path component (maybe with slashes)
+        part
+      end
+    end
+  end
+end

--- a/vendor/gems/globby-0.1.2/lib/globby/globject.rb
+++ b/vendor/gems/globby-0.1.2/lib/globby/globject.rb
@@ -1,0 +1,18 @@
+module Globby
+  class GlObject
+    attr_reader :files, :dirs
+
+    def initialize(files = Set.new, dirs = Set.new)
+      @files = files
+      @dirs = dirs
+    end
+
+    def self.all
+      files, dirs = Dir.glob('**/*', File::FNM_DOTMATCH).
+        reject { |f| f =~ /(\A|\/)\.\.?\z/ }.
+        partition { |f| File.file?(f) || File.symlink?(f) }
+      dirs.map!{ |d| d + "/" }
+      new(files, dirs)
+    end
+  end
+end

--- a/vendor/gems/globby-0.1.2/lib/globby/result.rb
+++ b/vendor/gems/globby-0.1.2/lib/globby/result.rb
@@ -1,0 +1,20 @@
+module Globby
+  class Result < Array
+    def initialize(files, dirs)
+      @dirs = dirs
+      super files.sort
+    end
+
+    def select(patterns)
+      Globby::select(patterns, to_globject)
+    end
+
+    def reject(patterns)
+      Globby::reject(patterns, to_globject)
+    end
+
+    def to_globject
+      GlObject.new(self, @dirs)
+    end
+  end
+end

--- a/vendor/gems/globby-0.1.2/spec/gitignore_spec.rb
+++ b/vendor/gems/globby-0.1.2/spec/gitignore_spec.rb
@@ -1,0 +1,109 @@
+require 'globby'
+require 'tmpdir'
+require 'fileutils'
+
+describe Globby do
+  around do |example|
+    gitignore_test { example.run }
+  end
+
+  describe ".select" do
+    it "should match .gitignore perfectly" do
+      rules = prepare_gitignore
+      expect(Globby.select(rules.split(/\n/))).to eq(all_files - git_files - untracked)
+    end
+  end
+
+  describe ".reject" do
+    it "should match the inverse of .gitignore, plus .git" do
+      rules = prepare_gitignore
+      expect(Globby.reject(rules.split(/\n/))).to eq(git_files + untracked)
+    end
+  end
+
+  def gitignore_test
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        prepare_files
+        `git init .`
+        yield
+      end
+    end
+  end
+
+  def prepare_gitignore
+    ignore = <<-IGNORE.gsub(/^ +/, '')
+      # here we go...
+
+      # some dotfiles
+      .hidden
+
+      # html, but just in the root
+      /*.html
+
+      # all rb files anywhere
+      *.rb
+
+      # except rb files immediately under foobar
+      !foobar/*.rb
+
+      # ooh look **
+      /a/**/*.yuss
+
+      # this will match foo/bar but not bar
+      bar/
+
+      # this will match nothing
+      foo*bar/baz.pdf
+
+      # this will match baz/ and foobar/baz/
+      baz
+
+      # check reinclusion
+      /spec/*
+      !/spec/noignore
+    IGNORE
+    File.open('.gitignore', 'w'){ |f| f.write ignore }
+    ignore
+  end
+
+  def prepare_files
+    files = <<-FILES.strip.split(/\s+/)
+      .gitignore
+      foo.rb
+      foo.html
+      bar
+      baz/lol.txt
+      foo/.hidden
+      foo/bar.rb
+      foo/bar.html
+      foo/bar/baz.pdf
+      foobar/.hidden
+      foobar/baz.txt
+      foobar/baz.rb
+      foobar/baz/lol.wut
+      a/a.yuss
+      a/a/a/a/a.yuss
+      spec/nope
+      spec/noignore
+    FILES
+    files.each do |file|
+      FileUtils.mkdir_p File.dirname(file)
+      FileUtils.touch file
+    end
+  end
+
+  def untracked
+    `git status -uall --porcelain`.gsub(/^\?\? /m, '').split(/\n/)
+  end
+
+  def git_files
+    Dir.glob('.git/**/*', File::FNM_DOTMATCH).
+      select{ |f| File.symlink?(f) || File.file?(f) }.sort
+  end
+
+  def all_files
+    Dir.glob('**/*', File::FNM_DOTMATCH).
+      select{ |f| File.symlink?(f) || File.file?(f) }.sort
+  end
+end

--- a/vendor/gems/globby-0.1.2/spec/globby_spec.rb
+++ b/vendor/gems/globby-0.1.2/spec/globby_spec.rb
@@ -1,0 +1,93 @@
+require 'globby'
+
+describe Globby do
+  it "should support chaining" do
+    files = files(%w{foo/bar.rb foo/baz.rb foo/c/bar.html foo/c/c/bar.rb})
+    expect(Globby.select(%w{*rb}, files).
+                  reject(%w{baz*}).
+                  select(%w{c})).to eq %w{foo/c/c/bar.rb}
+  end
+
+  describe ".select" do
+    context "a blank line" do
+      it "should return nothing" do
+        files = files("foo")
+        expect(Globby.select([""], files)).to eq []
+      end
+    end
+
+    context "a comment" do
+      it "should return nothing" do
+        files = files("foo")
+        expect(Globby.select(["#"], files)).to eq []
+      end
+    end
+
+    context "a pattern ending in a slash" do
+      it "should return a matching directory's contents" do
+        files = files(%w{foo/bar/baz foo/bar/baz2})
+        expect(Globby.select(%w{bar/}, files)).to eq %w{foo/bar/baz foo/bar/baz2}
+      end
+
+      it "should ignore symlinks and regular files" do
+        files = files(%w{foo/bar bar/baz})
+        expect(Globby.select(%w{bar/}, files)).to eq %w{bar/baz}
+      end
+    end
+
+    context "a pattern starting in a slash" do
+      it "should return only root glob matches" do
+        files = files(%w{foo/bar bar/foo})
+        expect(Globby.select(%w{/foo}, files)).to eq %w{foo/bar}
+      end
+    end
+
+    context "a pattern with a *" do
+      it "should return matching files" do
+        files = files(%w{foo/bar foo/baz})
+        expect(Globby.select(%w{*z}, files)).to eq %w{foo/baz}
+      end
+
+      it "should not glob slashes" do
+        files = files(%w{foo/bar foo/baz})
+        expect(Globby.select(%w{foo*bar}, files)).to eq []
+      end
+    end
+
+    context "a pattern with a ?" do
+      it "should return matching files" do
+        files = files(%w{foo/bar foo/baz})
+        expect(Globby.select(%w{b?z}, files)).to eq %w{foo/baz}
+      end
+
+      it "should not glob slashes" do
+        files = files(%w{foo/bar foo/baz})
+        expect(Globby.select(%w{foo?bar}, files)).to eq []
+      end
+    end
+
+    context "a pattern with a **" do
+      it "should match directories recursively" do
+        files = files(%w{foo/bar foo/baz foo/c/bar foo/c/c/bar})
+        expect(Globby.select(%w{foo/**/bar}, files)).to eq %w{foo/bar foo/c/bar foo/c/c/bar}
+      end
+    end
+
+    context "a pattern with bracket expressions" do
+      it "should return matching files" do
+        files = files(%w{boo fob f0o foo/bar poo/baz})
+        expect(Globby.select(%w{[e-g][0-9[:alpha:]][!b]}, files)).to eq %w{f0o foo/bar}
+      end
+    end
+  end
+
+  def files(files)
+    files = Array(files)
+    files.sort!
+    dirs = files.grep(/\//).map(&:dup).inject([]) { |ary, file|
+      ary << file while file.sub!(/[^\/]+\z/, '')
+      ary
+    }.uniq.sort
+    Globby::GlObject.new files, dirs
+  end
+end


### PR DESCRIPTION
Hi, i have the same issue #352 for installation with Capistrano

After some research, i found this two links https://github.com/bundler/bundler/pull/2023 https://github.com/bundler/bundler/pull/2023/commits/ed20cd7dde6cd22306902db16d655418e8593b66

In gemspec file, we use a git command, this is not a good practice.
I propose this PR for remove this command
