### PR TITLE
Add Phusion Passenger dotfolder to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ Design
 *~
 *.swp
 *.gem
+
+.passenger


### PR DESCRIPTION
On Official Phusion Passenger Docker images you get the `.passenger` folder which would be nice to have ignored. 