### PR TITLE
Fix #594 ruby_dep dependency installation break

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # fig run web bundle exec rake db:create db:schema:load ffcrm:demo:load
 # fig up
 
-FROM phusion/passenger-ruby21
+FROM phusion/passenger-ruby24
 MAINTAINER Steve Kenworthy
 
 RUN apt-get update \


### PR DESCRIPTION
Update Docker base image to Phusion's Ruby 2.4