### PR TITLE
Translation for Ransack pt-BR

### DIFF
--- a/config/locales/pt-BR_ransack.yml
+++ b/config/locales/pt-BR_ransack.yml
@@ -1,0 +1,81 @@
+---
+pt-BR:
+  ransack:
+    search: pesquisar
+    predicate: predicado
+    and: e
+    or: ou
+    any: algum
+    all: todos
+    combinator: combinador
+    attribute: atributo
+    value: valor
+    condition: condição
+    sort: ordenar
+    asc: crescente
+    desc: decrescente
+    submit: Pesquisar
+    add_group: Incluir grupo de filtro(s)
+    group_first: Mostrar resultados que correspondam a %{combinator} abaixo
+    group_rest: ! '...e que correspondam a %{combinator} abaixo'
+    add_condition: Incluir filtro
+    remove_condition: Remover filtro
+    predicates:
+      eq: igual
+      eq_any: igual a algum
+      eq_all: igual a todos
+      not_eq: não é igual a
+      not_eq_any: não é igual a algum
+      not_eq_all: não é igual a todos
+      matches: corresponde
+      matches_any: corresponde a algum
+      matches_all: corresponde a todos
+      does_not_match: não corresponde
+      does_not_match_any: não corresponde a algum
+      does_not_match_all: não corresponde a todos
+      lt: menor que
+      lt_any: menor que algum
+      lt_all: menor que todos
+      lteq: menor ou igual a
+      lteq_any: menor ou igual a algum
+      lteq_all: menor ou igual a todos
+      gt: maior que
+      gt_any: maior que algum
+      gt_all: maior que todos
+      gteq: maior que ou igual a
+      gteq_any: maior que ou igual a algum
+      gteq_all: maior que ou igual a todos
+      in: em
+      in_any: em algum
+      in_all: em todos
+      not_in: não em
+      not_in_any: não em algum
+      not_in_all: não em todos
+      cont: contém
+      cont_any: contém algum
+      cont_all: contém todos
+      not_cont: não contém
+      not_cont_any: não contém algum
+      not_cont_all: não contém todos
+      start: começa com
+      start_any: começa com algum
+      start_all: começa com todos
+      not_start: não começa com
+      not_start_any: não começa com algum
+      not_start_all: não começa com algum
+      end: termina com
+      end_any: termina com algum
+      end_all: termina com todos
+      not_end: não termina com
+      not_end_any: não termina com algum
+      not_end_all: não termina com todos
+      'true': é verdadeiro
+      'false': é falso
+      present: está presente
+      blank: está em branco
+      'null': é nulo
+      not_null: não é nulo
+      alt:
+        date:
+          lt: é antes de
+          gt: é depois de


### PR DESCRIPTION
Translation of ransack terms to portuguese.
Based on: https://github.com/activerecord-hackery/ransack/blob/master/lib/ransack/locale/pt-BR.yml