### PR TITLE
Long comment broken UI fix

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -704,7 +704,8 @@ ul.tools {
 
 .mail.highlight,
 .comment.highlight {
-  background-color: #f2f2f2; }
+  background-color: #f2f2f2;
+  word-break: break-all; }
 
 .highlight:hover {
   background-color: seashell;


### PR DESCRIPTION
If there is a long URL in the comment, the options to Edit, Convert etc hide in the right (x coordinate). The comment doesn't break into new line properly. Added a fix for that by adding `word-break: break-all;` to the common.scss file.