### PR TITLE
README: Use SVG for badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# Fat Free CRM [![TravisCI][travis-img-url]][travis-ci-url]  [![Code Climate](https://codeclimate.com/github/fatfreecrm/fat_free_crm.png)](https://codeclimate.com/github/fatfreecrm/fat_free_crm)
+# Fat Free CRM [![TravisCI][travis-img-url]][travis-ci-url]  [![Code Climate][codeclimate-img-url]][codeclimate-url]
 
-[travis-img-url]: https://secure.travis-ci.org/fatfreecrm/fat_free_crm.png?branch=master
+[travis-img-url]: https://secure.travis-ci.org/fatfreecrm/fat_free_crm.svg?branch=master
 [travis-ci-url]: https://travis-ci.org/fatfreecrm/fat_free_crm
+[codeclimate-img-url]: https://codeclimate.com/github/fatfreecrm/fat_free_crm.svg
+[codeclimate-url]: https://codeclimate.com/github/fatfreecrm/fat_free_crm
 
 ### An open source, Ruby on Rails [customer relationship management][crm-wiki] platform (CRM).
 


### PR DESCRIPTION
This PR changes the build badges to SVG for sharper readability ✨

(It also harmonizes usage of Markdown in the badge section.)