### PR TITLE
Fix license Rake task

### DIFF
--- a/app/assets/javascripts/crm_sortable.js.coffee
+++ b/app/assets/javascripts/crm_sortable.js.coffee
@@ -1,3 +1,8 @@
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
 (($) ->
   window.crm ||= {}
 

--- a/app/assets/javascripts/timeago.js.coffee
+++ b/app/assets/javascripts/timeago.js.coffee
@@ -1,3 +1,8 @@
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
 (($) ->
 
   # Run function on page load

--- a/app/assets/stylesheets/about.css.scss
+++ b/app/assets/stylesheets/about.css.scss
@@ -1,3 +1,8 @@
+// Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+//
+// Fat Free CRM is freely distributable under the terms of MIT license.
+// See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+//------------------------------------------------------------------------------
 #about > ul {
   margin-left: 15px;
 }

--- a/app/helpers/javascript_helper.rb
+++ b/app/helpers/javascript_helper.rb
@@ -1,3 +1,8 @@
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
 # Copied from prototype-rails which is no longer maintained
 
 module JavascriptHelper

--- a/app/helpers/remote_link_pagination_helper.rb
+++ b/app/helpers/remote_link_pagination_helper.rb
@@ -1,3 +1,8 @@
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
 module RemoteLinkPaginationHelper
   class LinkRenderer < WillPaginate::ActionView::LinkRenderer
     def link(text, target, attributes = {})

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,8 @@
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,8 @@
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,3 +1,8 @@
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.action_dispatch.cookies_serializer = :marshal

--- a/config/initializers/custom_field_ransack_translations.rb
+++ b/config/initializers/custom_field_ransack_translations.rb
@@ -1,3 +1,8 @@
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
 # Load field names for custom fields, for Ransack search
 if Setting.database_and_table_exists?
   Rails.application.config.after_initialize do

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,8 @@
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,8 @@
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,1 +1,6 @@
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
 PaperTrail.config.track_associations = false

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,8 @@
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
 # Be sure to restart your server when you modify this file.
 
 if FatFreeCRM.application?

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,3 +1,8 @@
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/lib/development_tasks/license.rake
+++ b/lib/development_tasks/license.rake
@@ -22,11 +22,13 @@ namespace :license do
   ],
             js: [
               "app/assets/javascripts/**/*.js",
+              "app/assets/javascripts/**/*.js.erb",
               "app/assets/stylesheets/**/*.sass", # Sass also uses javascript style comments
               "app/assets/stylesheets/**/*.scss"
             ],
             css: [
-              "app/assets/stylesheets/**/*.css"
+              "app/assets/stylesheets/**/*.css",
+              "app/assets/stylesheets/**/*.css.erb"
             ] }
 
   LICENSE_RB = %{# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
@@ -37,12 +39,11 @@ namespace :license do
 }
   LICENSES = { ruby: LICENSE_RB,
                js: LICENSE_RB.gsub(/^#/, "//"),
-               css: LICENSE_RB.gsub(/^# Fat Free/, "/*\n * Fat Free")
-                    .gsub(/^#/, " \*").sub(/---\n/, "---\n */") }
+               css: "/*\n" + LICENSE_RB.gsub(/^#/, ' *').sub(/---\n/, "---\n */\n") }
 
-  REGEXPS  = { ruby: /^# Fat Free CRM\n# Copyright \(C\).*?\n(#.*\n)*#-{10}-*\n*/,
-               js: /^\/\/ Fat Free CRM\n\/\/ Copyright \(C\).*?\n(\/\/.*\n)*\/\/-{10}-*\n*/,
-               css: /^\/\*\n \* Fat Free CRM\n \* Copyright \(C\).*?\n( \*.*\n)* \*-{10}-*\n \*\/\n*/ }
+  REGEXPS  = { ruby: /^# Copyright \(c\).*?\n(?:#.*\n)*?#-{10}-*\n/,
+               js: /^\/\/ Copyright \(c\).*?\n(?:\/\/.*\n)*?\/\/-{10}-*\n/,
+               css: /^\/\*\n \* Copyright \(c\).*?\n(?: \*.*\n)*? \*-{10}-*\n \*\/\n/ }
 
   def expand_globs(globs)
     globs.map { |f| Dir.glob(f) }.flatten.uniq
@@ -52,11 +53,13 @@ namespace :license do
   task :add do
     FILES.each do |lang, globs|
       expand_globs(globs).each do |file|
-        puts "== Adding license to '#{file}'..."
         old_content = File.read(file)
         new_content = LICENSES[lang] + old_content.sub(REGEXPS[lang], '')
 
-        File.open(file, "wb") { |f| f.puts new_content }
+        if new_content != old_content
+          File.open(file, "wb") { |f| f.puts new_content }
+          puts "== Added license to #{file}"
+        end
       end
     end
   end
@@ -69,7 +72,7 @@ namespace :license do
         new_content = old_content.sub(REGEXPS[lang], '')
         if new_content != old_content
           File.open(file, "wb") { |f| f.puts new_content }
-          puts "Removed license from '#{file}'."
+          puts "== Removed license from #{file}"
         end
       end
     end

--- a/spec/models/users/abilities/user_ability_spec.rb
+++ b/spec/models/users/abilities/user_ability_spec.rb
@@ -1,3 +1,8 @@
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
 require 'spec_helper'
 require 'cancan/matchers'
 


### PR DESCRIPTION
The license:add / license:remove Rake tasks were broken. This PR fixes them, and then adds the license header where it was missing. For consistency I've kept it as (c) 2008-2013 on these files. You can update the date on files in a future PR if you'd like.

Other changes:
- Include .css.erb and .js.erb in scope
- license:add only write to file if there was a change (same as how :remove works currently)
