### PR TITLE
Use headless Chrome browser for feature testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,14 @@ language: ruby
 rvm:
   - 2.3.3
   # - 2.4.0
+
 env:
-  - DB=mysql
-  - DB=postgres
-  - DB=sqlite
+  global:
+    - BROWSER=chrome
+  matrix:
+    - DB=mysql
+    - DB=postgres
+    - DB=sqlite
 
 matrix:
   exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ end
 group :test do
   gem 'capybara'
   gem 'selenium-webdriver'
+  gem 'chromedriver-helper'
   gem 'database_cleaner'
   gem "acts_as_fu"
   gem 'zeus' unless ENV["CI"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,8 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
+    archive-zip (0.7.0)
+      io-like (~> 0.3.0)
     arel (7.1.4)
     ast (2.3.0)
     authlogic (3.6.0)
@@ -79,15 +81,18 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
-    capybara (2.14.4)
+    capybara (2.15.4)
       addressable
-      mime-types (>= 1.16)
+      mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     childprocess (0.7.1)
       ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.1.0)
+      archive-zip (~> 0.7.0)
+      nokogiri (~> 1.6)
     chronic (0.10.2)
     climate_control (0.2.0)
     cocaine (0.5.8)
@@ -158,6 +163,7 @@ GEM
     htmlentities (4.3.4)
     i18n (0.8.6)
     i18n_data (0.7.0)
+    io-like (0.3.0)
     jquery-migrate-rails (1.2.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
@@ -181,6 +187,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mimemagic (0.3.2)
+    mini_mime (0.1.4)
     mini_portile2 (2.2.0)
     minitest (5.10.2)
     money (6.9.0)
@@ -339,7 +346,7 @@ GEM
       ffi-compiler (>= 1.0, < 2.0)
     select2-rails (4.0.3)
       thor (~> 0.14)
-    selenium-webdriver (3.4.4)
+    selenium-webdriver (3.6.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
     shellany (0.0.1)
@@ -408,6 +415,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-rvm
   capybara
+  chromedriver-helper
   cocaine
   coffee-rails
   coffee-script-source (~> 1.8, >= 1.8.0)

--- a/spec/features/support/browser.rb
+++ b/spec/features/support/browser.rb
@@ -8,11 +8,15 @@
 #
 if ENV['BROWSER'] == 'chrome'
   Capybara.register_driver :selenium do |app|
-    Capybara::Selenium::Driver.new(app, browser: :chrome)
+    capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: { args: %w(no-sandbox headless disable-gpu) })
+    Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
   end
 else
   Capybara.register_driver :selenium do |app|
-    Capybara::Selenium::Driver.new(app, browser: :firefox, desired_capabilities: Selenium::WebDriver::Remote::Capabilities.firefox(marionette: false))
+    options = Selenium::WebDriver::Firefox::Options.new
+    options.args << '--headless'
+    capabilities = Selenium::WebDriver::Remote::Capabilities.firefox(marionette: false)
+    Capybara::Selenium::Driver.new(app, browser: :firefox, options: options, desired_capabilities: capabilities)
   end
 end
 


### PR DESCRIPTION
Use headless Chrome browser for feature testing as Firefox seems shaky.
Also updates capybara and selenium-webdriver gems and adds chromedriver-helper.

The run time in Travis is now 8 min vs. 14 minutes previously!

Another reason to use Chrome over Firefox:

![image](https://user-images.githubusercontent.com/27655/31940142-0a90b22c-b8f8-11e7-866a-f57daa666a44.png)
