### PR TITLE
Windows support + Puma + Bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ remove 'fat_free_crm'
 group :development do
   # don't load these gems in travis
   unless ENV["CI"]
-    gem 'thin'
+    gem 'puma'
     gem 'capistrano'
     gem 'capistrano-bundler'
     gem 'capistrano-rails'
@@ -69,8 +69,8 @@ group :test do
   gem 'selenium-webdriver'
   gem 'chromedriver-helper'
   gem 'database_cleaner'
-  gem "acts_as_fu"
-  gem 'zeus' unless ENV["CI"]
+  gem 'acts_as_fu'
+  gem 'zeus', platform: :ruby unless ENV["CI"]
   gem 'timecop'
 end
 
@@ -86,3 +86,5 @@ gem 'execjs'
 gem 'therubyracer', platform: :ruby unless ENV["CI"]
 gem 'nokogiri', '>= 1.8.1'
 gem 'activemodel-serializers-xml'
+gem 'bootsnap', require: false
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,8 @@ GEM
       activesupport (>= 3.2, < 5.2)
       request_store (~> 1.0)
       scrypt (>= 1.2, < 4.0)
+    bootsnap (1.1.6)
+      msgpack (~> 1.0)
     builder (3.2.3)
     byebug (9.0.6)
     cancancan (2.0.0)
@@ -117,13 +119,11 @@ GEM
     crass (1.0.3)
     css_parser (1.5.0)
       addressable
-    daemons (1.2.4)
     database_cleaner (1.6.1)
     diff-lcs (1.3)
     dynamic_form (1.1.4)
     email_reply_parser_ffcrm (0.5.0)
     erubis (2.7.0)
-    eventmachine (1.2.3)
     execjs (2.7.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -194,6 +194,7 @@ GEM
     minitest (5.10.3)
     money (6.9.0)
       i18n (>= 0.6.4, < 0.9)
+    msgpack (1.2.0)
     nenv (0.3.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -231,6 +232,7 @@ GEM
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (2.0.5)
+    puma (3.11.0)
     rack (2.0.3)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -374,16 +376,14 @@ GEM
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
-    thin (1.7.2)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.7)
     timecop (0.9.1)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2017.3)
+      tzinfo (>= 1.0.0)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
@@ -410,6 +410,7 @@ DEPENDENCIES
   acts_as_fu
   acts_as_list
   authlogic (>= 3.4.4)
+  bootsnap
   byebug
   cancancan
   capistrano
@@ -443,6 +444,7 @@ DEPENDENCIES
   pg
   premailer
   pry-rails
+  puma
   rails (~> 5.0.0)
   rails-controller-testing
   rails-observers
@@ -467,13 +469,13 @@ DEPENDENCIES
   simple_form
   sprockets-rails (>= 3.0.0)
   therubyracer
-  thin
   thor
   timecop
+  tzinfo-data
   uglifier
   unicorn
   will_paginate
   zeus
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -8,3 +8,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'bootsnap/setup'


### PR DESCRIPTION
- Use puma instead of thin (standard for rails, works better on windows)
- Zeus should not run on windows
- Add tzinfo-data for windows
- require 'rake/task' needed for windows
- Add bootsnap to gemfile to improve boot times / reduce test run by 3 minutes (8:30 vs 11:30 previously.) It will be the standard in Rails 5.2