### PR TITLE
Upgrade Migrations (preparation for Rails 5.1)

### DIFF
--- a/db/migrate/20100928030598_create_sessions.rb
+++ b/db/migrate/20100928030598_create_sessions.rb
@@ -1,4 +1,4 @@
-class CreateSessions < ActiveRecord::Migration
+class CreateSessions < ActiveRecord::Migration[4.2]
   def self.up
     # Set the following global variable to show that we are migrating
     # from a brand new database. Future migrations can detect this, and

--- a/db/migrate/20100928030599_create_users.rb
+++ b/db/migrate/20100928030599_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def self.up
     create_table :users, force: true do |t|
       t.string :uuid,             limit: 36

--- a/db/migrate/20100928030600_create_openid_tables.rb
+++ b/db/migrate/20100928030600_create_openid_tables.rb
@@ -1,4 +1,4 @@
-class CreateOpenidTables < ActiveRecord::Migration
+class CreateOpenidTables < ActiveRecord::Migration[4.2]
   def self.up
     create_table :open_id_authentication_associations, force: true do |t|
       t.integer :issued

--- a/db/migrate/20100928030601_create_accounts.rb
+++ b/db/migrate/20100928030601_create_accounts.rb
@@ -1,4 +1,4 @@
-class CreateAccounts < ActiveRecord::Migration
+class CreateAccounts < ActiveRecord::Migration[4.2]
   def self.up
     create_table :accounts, force: true do |t|
       t.string :uuid, limit: 36

--- a/db/migrate/20100928030602_create_permissions.rb
+++ b/db/migrate/20100928030602_create_permissions.rb
@@ -1,4 +1,4 @@
-class CreatePermissions < ActiveRecord::Migration
+class CreatePermissions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :permissions, force: true do |t|
       t.references :user                          # User who is allowed to access the asset.

--- a/db/migrate/20100928030603_create_settings.rb
+++ b/db/migrate/20100928030603_create_settings.rb
@@ -1,4 +1,4 @@
-class CreateSettings < ActiveRecord::Migration
+class CreateSettings < ActiveRecord::Migration[4.2]
   def self.up
     create_table :settings, force: true do |t|
       t.string :name, limit: 32, null: false, default: ""

--- a/db/migrate/20100928030604_create_preferences.rb
+++ b/db/migrate/20100928030604_create_preferences.rb
@@ -1,4 +1,4 @@
-class CreatePreferences < ActiveRecord::Migration
+class CreatePreferences < ActiveRecord::Migration[4.2]
   def self.up
     create_table :preferences do |t|
       t.references :user

--- a/db/migrate/20100928030605_create_campaigns.rb
+++ b/db/migrate/20100928030605_create_campaigns.rb
@@ -1,4 +1,4 @@
-class CreateCampaigns < ActiveRecord::Migration
+class CreateCampaigns < ActiveRecord::Migration[4.2]
   def self.up
     create_table :campaigns, force: true do |t|
       t.string :uuid,   limit: 36

--- a/db/migrate/20100928030606_create_leads.rb
+++ b/db/migrate/20100928030606_create_leads.rb
@@ -1,4 +1,4 @@
-class CreateLeads < ActiveRecord::Migration
+class CreateLeads < ActiveRecord::Migration[4.2]
   def self.up
     create_table :leads, force: true do |t|
       t.string :uuid,   limit: 36

--- a/db/migrate/20100928030607_create_contacts.rb
+++ b/db/migrate/20100928030607_create_contacts.rb
@@ -1,4 +1,4 @@
-class CreateContacts < ActiveRecord::Migration
+class CreateContacts < ActiveRecord::Migration[4.2]
   def self.up
     create_table :contacts, force: true do |t|
       t.string :uuid,   limit: 36

--- a/db/migrate/20100928030608_create_opportunities.rb
+++ b/db/migrate/20100928030608_create_opportunities.rb
@@ -1,4 +1,4 @@
-class CreateOpportunities < ActiveRecord::Migration
+class CreateOpportunities < ActiveRecord::Migration[4.2]
   def self.up
     create_table :opportunities, force: true do |t|
       t.string :uuid,     limit: 36

--- a/db/migrate/20100928030609_create_account_contacts.rb
+++ b/db/migrate/20100928030609_create_account_contacts.rb
@@ -1,4 +1,4 @@
-class CreateAccountContacts < ActiveRecord::Migration
+class CreateAccountContacts < ActiveRecord::Migration[4.2]
   def self.up
     create_table :account_contacts, force: true do |t|
       t.references :account

--- a/db/migrate/20100928030610_create_account_opportunities.rb
+++ b/db/migrate/20100928030610_create_account_opportunities.rb
@@ -1,4 +1,4 @@
-class CreateAccountOpportunities < ActiveRecord::Migration
+class CreateAccountOpportunities < ActiveRecord::Migration[4.2]
   def self.up
     create_table :account_opportunities, force: true do |t|
       t.references :account

--- a/db/migrate/20100928030611_create_contact_opportunities.rb
+++ b/db/migrate/20100928030611_create_contact_opportunities.rb
@@ -1,4 +1,4 @@
-class CreateContactOpportunities < ActiveRecord::Migration
+class CreateContactOpportunities < ActiveRecord::Migration[4.2]
   def self.up
     create_table :contact_opportunities, force: true do |t|
       t.references :contact

--- a/db/migrate/20100928030612_create_tasks.rb
+++ b/db/migrate/20100928030612_create_tasks.rb
@@ -1,4 +1,4 @@
-class CreateTasks < ActiveRecord::Migration
+class CreateTasks < ActiveRecord::Migration[4.2]
   def self.up
     create_table :tasks, force: true do |t|
       t.string :uuid, limit: 36

--- a/db/migrate/20100928030613_create_comments.rb
+++ b/db/migrate/20100928030613_create_comments.rb
@@ -1,4 +1,4 @@
-class CreateComments < ActiveRecord::Migration
+class CreateComments < ActiveRecord::Migration[4.2]
   def self.up
     create_table :comments, force: true do |t|
       t.references :user

--- a/db/migrate/20100928030614_create_activities.rb
+++ b/db/migrate/20100928030614_create_activities.rb
@@ -1,4 +1,4 @@
-class CreateActivities < ActiveRecord::Migration
+class CreateActivities < ActiveRecord::Migration[4.2]
   def self.up
     create_table :activities, force: true do |t|
       t.references :user                                           # User who's activity gets recorded.

--- a/db/migrate/20100928030615_create_avatars.rb
+++ b/db/migrate/20100928030615_create_avatars.rb
@@ -1,4 +1,4 @@
-class CreateAvatars < ActiveRecord::Migration
+class CreateAvatars < ActiveRecord::Migration[4.2]
   def self.up
     create_table :avatars do |t|
       t.references :user                         # Who uploaded the avatar.

--- a/db/migrate/20100928030616_rename_remember_token.rb
+++ b/db/migrate/20100928030616_rename_remember_token.rb
@@ -1,4 +1,4 @@
-class RenameRememberToken < ActiveRecord::Migration
+class RenameRememberToken < ActiveRecord::Migration[4.2]
   def self.up
     rename_column :users, :remember_token, :persistence_token
     remove_column :users, :openid_identifier

--- a/db/migrate/20100928030617_drop_openid_tables.rb
+++ b/db/migrate/20100928030617_drop_openid_tables.rb
@@ -1,4 +1,4 @@
-class DropOpenidTables < ActiveRecord::Migration
+class DropOpenidTables < ActiveRecord::Migration[4.2]
   def self.up
     drop_table :open_id_authentication_associations
     drop_table :open_id_authentication_nonces

--- a/db/migrate/20100928030618_add_admin_to_users.rb
+++ b/db/migrate/20100928030618_add_admin_to_users.rb
@@ -1,4 +1,4 @@
-class AddAdminToUsers < ActiveRecord::Migration
+class AddAdminToUsers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :admin, :boolean, null: false, default: false
     superuser = User.first

--- a/db/migrate/20100928030619_add_suspended_to_users.rb
+++ b/db/migrate/20100928030619_add_suspended_to_users.rb
@@ -1,4 +1,4 @@
-class AddSuspendedToUsers < ActiveRecord::Migration
+class AddSuspendedToUsers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :suspended_at, :datetime
     rename_column :accounts, :tall_free_phone, :toll_free_phone

--- a/db/migrate/20100928030620_remove_uuid.rb
+++ b/db/migrate/20100928030620_remove_uuid.rb
@@ -1,4 +1,4 @@
-class RemoveUuid < ActiveRecord::Migration
+class RemoveUuid < ActiveRecord::Migration[4.2]
   @@uuid_configured = false
 
   def self.up

--- a/db/migrate/20100928030621_add_email_to_accounts.rb
+++ b/db/migrate/20100928030621_add_email_to_accounts.rb
@@ -1,4 +1,4 @@
-class AddEmailToAccounts < ActiveRecord::Migration
+class AddEmailToAccounts < ActiveRecord::Migration[4.2]
   def self.up
     add_column :accounts, :email, :string, limit: 64
   end

--- a/db/migrate/20100928030622_add_background_info_to_models.rb
+++ b/db/migrate/20100928030622_add_background_info_to_models.rb
@@ -1,4 +1,4 @@
-class AddBackgroundInfoToModels < ActiveRecord::Migration
+class AddBackgroundInfoToModels < ActiveRecord::Migration[4.2]
   def self.up
     add_column :accounts, :background_info, :string
     add_column :campaigns, :background_info, :string

--- a/db/migrate/20100928030623_create_addresses.rb
+++ b/db/migrate/20100928030623_create_addresses.rb
@@ -1,4 +1,4 @@
-class CreateAddresses < ActiveRecord::Migration
+class CreateAddresses < ActiveRecord::Migration[4.2]
   def self.up
     create_table :addresses do |t|
       t.string :street1

--- a/db/migrate/20100928030624_add_index_on_permissions.rb
+++ b/db/migrate/20100928030624_add_index_on_permissions.rb
@@ -1,4 +1,4 @@
-class AddIndexOnPermissions < ActiveRecord::Migration
+class AddIndexOnPermissions < ActiveRecord::Migration[4.2]
   def self.up
     add_index :permissions, [:asset_id, :asset_type]
   end

--- a/db/migrate/20100928030625_create_emails.rb
+++ b/db/migrate/20100928030625_create_emails.rb
@@ -1,4 +1,4 @@
-class CreateEmails < ActiveRecord::Migration
+class CreateEmails < ActiveRecord::Migration[4.2]
   def self.up
     create_table :emails, force: true do |t|
       t.string :imap_message_id, null: false  # IMAP internal message identifier.

--- a/db/migrate/20100928030626_add_state_to_timeline_objects.rb
+++ b/db/migrate/20100928030626_add_state_to_timeline_objects.rb
@@ -1,4 +1,4 @@
-class AddStateToTimelineObjects < ActiveRecord::Migration
+class AddStateToTimelineObjects < ActiveRecord::Migration[4.2]
   def self.up
     add_column :comments, :state, :string, limit: 16, null: false, default: "Expanded"
     add_column :emails,   :state, :string, limit: 16, null: false, default: "Expanded"

--- a/db/migrate/20100928030627_acts_as_taggable_on_migration.rb
+++ b/db/migrate/20100928030627_acts_as_taggable_on_migration.rb
@@ -1,4 +1,4 @@
-class ActsAsTaggableOnMigration < ActiveRecord::Migration
+class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]
   def self.up
     create_table :tags do |t|
       t.column :name, :string

--- a/db/migrate/20101221123456_add_single_access_token_to_users.rb
+++ b/db/migrate/20101221123456_add_single_access_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddSingleAccessTokenToUsers < ActiveRecord::Migration
+class AddSingleAccessTokenToUsers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :single_access_token, :string
   end

--- a/db/migrate/20101221345678_add_rating_and_category_to_accounts.rb
+++ b/db/migrate/20101221345678_add_rating_and_category_to_accounts.rb
@@ -1,4 +1,4 @@
-class AddRatingAndCategoryToAccounts < ActiveRecord::Migration
+class AddRatingAndCategoryToAccounts < ActiveRecord::Migration[4.2]
   def self.up
     add_column :accounts, :rating, :integer, default: 0, null: false
     add_column :accounts, :category, :string, limit: 32

--- a/db/migrate/20110719082054_add_skype_to_contacts_and_leads.rb
+++ b/db/migrate/20110719082054_add_skype_to_contacts_and_leads.rb
@@ -1,4 +1,4 @@
-class AddSkypeToContactsAndLeads < ActiveRecord::Migration
+class AddSkypeToContactsAndLeads < ActiveRecord::Migration[4.2]
   def self.up
     add_column :contacts, :skype, :string, limit: 128
     add_column :leads, :skype, :string, limit: 128

--- a/db/migrate/20111101083437_create_fields.rb
+++ b/db/migrate/20111101083437_create_fields.rb
@@ -1,4 +1,4 @@
-class CreateFields < ActiveRecord::Migration
+class CreateFields < ActiveRecord::Migration[4.2]
   def self.up
     create_table :fields, force: true do |t|
       t.string :type

--- a/db/migrate/20111101090312_create_field_groups.rb
+++ b/db/migrate/20111101090312_create_field_groups.rb
@@ -1,4 +1,4 @@
-class CreateFieldGroups < ActiveRecord::Migration
+class CreateFieldGroups < ActiveRecord::Migration[4.2]
   def self.up
     create_table :field_groups do |t|
       t.string :name,        limit: 64

--- a/db/migrate/20111116091952_add_field_groups_tag_id.rb
+++ b/db/migrate/20111116091952_add_field_groups_tag_id.rb
@@ -1,4 +1,4 @@
-class AddFieldGroupsTagId < ActiveRecord::Migration
+class AddFieldGroupsTagId < ActiveRecord::Migration[4.2]
   def self.up
     add_column :field_groups, :tag_id, :integer
   end

--- a/db/migrate/20111117041311_change_fields_collection_to_text.rb
+++ b/db/migrate/20111117041311_change_fields_collection_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeFieldsCollectionToText < ActiveRecord::Migration
+class ChangeFieldsCollectionToText < ActiveRecord::Migration[4.2]
   def self.up
     change_column :fields, :collection, :text
   end

--- a/db/migrate/20111201030535_add_field_groups_klass_name.rb
+++ b/db/migrate/20111201030535_add_field_groups_klass_name.rb
@@ -1,4 +1,4 @@
-class AddFieldGroupsKlassName < ActiveRecord::Migration
+class AddFieldGroupsKlassName < ActiveRecord::Migration[4.2]
   def up
     add_column :field_groups, :klass_name, :string, limit: 32
 

--- a/db/migrate/20120121054235_create_lists.rb
+++ b/db/migrate/20120121054235_create_lists.rb
@@ -1,4 +1,4 @@
-class CreateLists < ActiveRecord::Migration
+class CreateLists < ActiveRecord::Migration[4.2]
   def change
     create_table :lists do |t|
       t.string :name

--- a/db/migrate/20120216031616_create_versions.rb
+++ b/db/migrate/20120216031616_create_versions.rb
@@ -1,4 +1,4 @@
-class CreateVersions < ActiveRecord::Migration
+class CreateVersions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :versions do |t|
       t.string :item_type, null: false

--- a/db/migrate/20120216042541_is_paranoid_to_paper_trail.rb
+++ b/db/migrate/20120216042541_is_paranoid_to_paper_trail.rb
@@ -1,4 +1,4 @@
-class IsParanoidToPaperTrail < ActiveRecord::Migration
+class IsParanoidToPaperTrail < ActiveRecord::Migration[4.2]
   def up
     [Account, Campaign, Contact, Lead, Opportunity, Task].each do |klass|
       klass.where('deleted_at IS NOT NULL').each(&:destroy)

--- a/db/migrate/20120220233724_add_versions_object_changes.rb
+++ b/db/migrate/20120220233724_add_versions_object_changes.rb
@@ -1,4 +1,4 @@
-class AddVersionsObjectChanges < ActiveRecord::Migration
+class AddVersionsObjectChanges < ActiveRecord::Migration[4.2]
   def up
     add_column :versions, :object_changes, :text
   end

--- a/db/migrate/20120224073107_remove_default_value_and_clear_settings.rb
+++ b/db/migrate/20120224073107_remove_default_value_and_clear_settings.rb
@@ -1,4 +1,4 @@
-class RemoveDefaultValueAndClearSettings < ActiveRecord::Migration
+class RemoveDefaultValueAndClearSettings < ActiveRecord::Migration[4.2]
   def up
     remove_column :settings, :default_value
 

--- a/db/migrate/20120309070209_add_versions_related.rb
+++ b/db/migrate/20120309070209_add_versions_related.rb
@@ -1,4 +1,4 @@
-class AddVersionsRelated < ActiveRecord::Migration
+class AddVersionsRelated < ActiveRecord::Migration[4.2]
   def change
     add_column :versions, :related_id, :integer
     add_column :versions, :related_type, :string

--- a/db/migrate/20120314080441_add_subscribed_users_to_entities.rb
+++ b/db/migrate/20120314080441_add_subscribed_users_to_entities.rb
@@ -1,4 +1,4 @@
-class AddSubscribedUsersToEntities < ActiveRecord::Migration
+class AddSubscribedUsersToEntities < ActiveRecord::Migration[4.2]
   def change
     %w(accounts campaigns contacts leads opportunities tasks).each do |table|
       add_column table.to_sym, :subscribed_users, :text

--- a/db/migrate/20120316045804_activities_to_versions.rb
+++ b/db/migrate/20120316045804_activities_to_versions.rb
@@ -1,4 +1,4 @@
-class ActivitiesToVersions < ActiveRecord::Migration
+class ActivitiesToVersions < ActiveRecord::Migration[4.2]
   def up
     events = {
       'created'     => 'create',

--- a/db/migrate/20120405080727_change_subscribed_users_to_set.rb
+++ b/db/migrate/20120405080727_change_subscribed_users_to_set.rb
@@ -1,4 +1,4 @@
-class ChangeSubscribedUsersToSet < ActiveRecord::Migration
+class ChangeSubscribedUsersToSet < ActiveRecord::Migration[4.2]
   def up
     contacts = connection.select_all %(
       SELECT id, subscribed_users

--- a/db/migrate/20120405080742_change_further_subscribed_users_to_set.rb
+++ b/db/migrate/20120405080742_change_further_subscribed_users_to_set.rb
@@ -1,4 +1,4 @@
-class ChangeFurtherSubscribedUsersToSet < ActiveRecord::Migration
+class ChangeFurtherSubscribedUsersToSet < ActiveRecord::Migration[4.2]
   def up
     # Change the other tables that were missing from the previous migration
     %w(campaigns opportunities leads tasks accounts).each do |table|

--- a/db/migrate/20120406082136_create_groups.rb
+++ b/db/migrate/20120406082136_create_groups.rb
@@ -1,4 +1,4 @@
-class CreateGroups < ActiveRecord::Migration
+class CreateGroups < ActiveRecord::Migration[4.2]
   def change
     create_table :groups do |t|
       t.string :name

--- a/db/migrate/20120413034923_add_index_on_versions_item_type.rb
+++ b/db/migrate/20120413034923_add_index_on_versions_item_type.rb
@@ -1,4 +1,4 @@
-class AddIndexOnVersionsItemType < ActiveRecord::Migration
+class AddIndexOnVersionsItemType < ActiveRecord::Migration[4.2]
   def change
     add_index :versions, :whodunnit
   end

--- a/db/migrate/20120510025219_add_not_null_constraints_for_timestamp_columns.rb
+++ b/db/migrate/20120510025219_add_not_null_constraints_for_timestamp_columns.rb
@@ -1,4 +1,4 @@
-class AddNotNullConstraintsForTimestampColumns < ActiveRecord::Migration
+class AddNotNullConstraintsForTimestampColumns < ActiveRecord::Migration[4.2]
   def up
     set_timestamp_constraints null: false unless $FFCRM_NEW_DATABASE
   end

--- a/db/migrate/20120528102124_increase_length_of_version_events.rb
+++ b/db/migrate/20120528102124_increase_length_of_version_events.rb
@@ -1,4 +1,4 @@
-class IncreaseLengthOfVersionEvents < ActiveRecord::Migration
+class IncreaseLengthOfVersionEvents < ActiveRecord::Migration[4.2]
   def up
     change_column :versions, :event, :string, limit: 512
   end

--- a/db/migrate/20120801032706_add_pair_id_to_fields.rb
+++ b/db/migrate/20120801032706_add_pair_id_to_fields.rb
@@ -1,4 +1,4 @@
-class AddPairIdToFields < ActiveRecord::Migration
+class AddPairIdToFields < ActiveRecord::Migration[4.2]
   def change
     add_column :fields, :pair_id, :integer
   end

--- a/db/migrate/20121003063155_add_settings_to_custom_fields.rb
+++ b/db/migrate/20121003063155_add_settings_to_custom_fields.rb
@@ -1,4 +1,4 @@
-class AddSettingsToCustomFields < ActiveRecord::Migration
+class AddSettingsToCustomFields < ActiveRecord::Migration[4.2]
   def change
     add_column :fields, :settings, :text, default: nil
   end

--- a/db/migrate/20121221033947_fix_country_mapping.rb
+++ b/db/migrate/20121221033947_fix_country_mapping.rb
@@ -1,4 +1,4 @@
-class FixCountryMapping < ActiveRecord::Migration
+class FixCountryMapping < ActiveRecord::Migration[4.2]
   def up
     message = """ Important note about countries. Please read carefully!
 

--- a/db/migrate/20131207033244_add_user_id_to_lists.rb
+++ b/db/migrate/20131207033244_add_user_id_to_lists.rb
@@ -1,4 +1,4 @@
-class AddUserIdToLists < ActiveRecord::Migration
+class AddUserIdToLists < ActiveRecord::Migration[4.2]
   def change
     add_column :lists, :user_id, :integer, default: nil
     add_index :lists, :user_id

--- a/db/migrate/20140916011927_add_created_at_index_on_versions.rb
+++ b/db/migrate/20140916011927_add_created_at_index_on_versions.rb
@@ -1,4 +1,4 @@
-class AddCreatedAtIndexOnVersions < ActiveRecord::Migration
+class AddCreatedAtIndexOnVersions < ActiveRecord::Migration[4.2]
   def change
     add_index :versions, :created_at
   end

--- a/db/migrate/20140916012922_add_indexes_to_model_associations.rb
+++ b/db/migrate/20140916012922_add_indexes_to_model_associations.rb
@@ -1,4 +1,4 @@
-class AddIndexesToModelAssociations < ActiveRecord::Migration
+class AddIndexesToModelAssociations < ActiveRecord::Migration[4.2]
   def change
     add_index :contact_opportunities, [:contact_id, :opportunity_id]
     add_index :account_opportunities, [:account_id, :opportunity_id]

--- a/db/migrate/20141126031837_increase_email_to254_chars.rb
+++ b/db/migrate/20141126031837_increase_email_to254_chars.rb
@@ -1,4 +1,4 @@
-class IncreaseEmailTo254Chars < ActiveRecord::Migration
+class IncreaseEmailTo254Chars < ActiveRecord::Migration[4.2]
   def up
     change_column :accounts, :email, :string, limit: 254
     change_column :contacts, :email, :string, limit: 254

--- a/db/migrate/20141230021159_add_transaction_id_column_to_versions.rb
+++ b/db/migrate/20141230021159_add_transaction_id_column_to_versions.rb
@@ -1,4 +1,4 @@
-class AddTransactionIdColumnToVersions < ActiveRecord::Migration
+class AddTransactionIdColumnToVersions < ActiveRecord::Migration[4.2]
   def self.up
     add_column :versions, :transaction_id, :integer
     add_index :versions, [:transaction_id]

--- a/db/migrate/20141230205453_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20141230205453_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from acts_as_taggable_on_engine (originally 2)
-class AddMissingUniqueIndices < ActiveRecord::Migration
+class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]
   def self.up
     add_index :tags, :name, unique: true
 

--- a/db/migrate/20141230205454_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20141230205454_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from acts_as_taggable_on_engine (originally 3)
-class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]
   def self.up
     add_column :tags, :taggings_count, :integer, default: 0
 

--- a/db/migrate/20141230205455_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20141230205455_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from acts_as_taggable_on_engine (originally 4)
-class AddMissingTaggableIndex < ActiveRecord::Migration
+class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]
   def self.up
     add_index :taggings, [:taggable_id, :taggable_type, :context]
   end

--- a/db/migrate/20150123060900_convert_radio_to_radio_buttons.rb
+++ b/db/migrate/20150123060900_convert_radio_to_radio_buttons.rb
@@ -1,4 +1,4 @@
-class ConvertRadioToRadioButtons < ActiveRecord::Migration
+class ConvertRadioToRadioButtons < ActiveRecord::Migration[4.2]
   def up
     # UPDATE "fields" SET "as" = 'radio_buttons' WHERE "fields"."as" = $1  [["as", "radio"]]
     Field.where(as: 'radio').update_all(as: 'radio_buttons')

--- a/db/migrate/20150227123054_remove_last_request_at_from_users.rb
+++ b/db/migrate/20150227123054_remove_last_request_at_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveLastRequestAtFromUsers < ActiveRecord::Migration
+class RemoveLastRequestAtFromUsers < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :last_request_at
   end

--- a/db/migrate/20150427131956_create_index_related_type.rb
+++ b/db/migrate/20150427131956_create_index_related_type.rb
@@ -1,4 +1,4 @@
-class CreateIndexRelatedType < ActiveRecord::Migration
+class CreateIndexRelatedType < ActiveRecord::Migration[4.2]
   def up
     add_index :versions, [:related_id, :related_type]
   end

--- a/db/migrate/20160511053730_add_account_contacts_index.rb
+++ b/db/migrate/20160511053730_add_account_contacts_index.rb
@@ -1,4 +1,4 @@
-class AddAccountContactsIndex < ActiveRecord::Migration
+class AddAccountContactsIndex < ActiveRecord::Migration[4.2]
   def change
     add_index :account_contacts, [:account_id, :contact_id]
   end


### PR DESCRIPTION
Add [4.2] version specifier to all migrations (preparation for Rails 5.1 upgrade)