### PR TITLE
Speed up builds with Bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,3 +86,4 @@ gem 'execjs'
 gem 'therubyracer', platform: :ruby unless ENV["CI"]
 gem 'nokogiri', '>= 1.8.1'
 gem 'activemodel-serializers-xml'
+gem 'bootsnap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,8 @@ GEM
       activesupport (>= 3.2, < 5.2)
       request_store (~> 1.0)
       scrypt (>= 1.2, < 4.0)
+    bootsnap (1.1.6)
+      msgpack (~> 1.0)
     builder (3.2.3)
     byebug (9.0.6)
     cancancan (2.0.0)
@@ -194,6 +196,7 @@ GEM
     minitest (5.10.3)
     money (6.9.0)
       i18n (>= 0.6.4, < 0.9)
+    msgpack (1.2.0)
     nenv (0.3.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -410,6 +413,7 @@ DEPENDENCIES
   acts_as_fu
   acts_as_list
   authlogic (>= 3.4.4)
+  bootsnap
   byebug
   cancancan
   capistrano
@@ -476,4 +480,4 @@ DEPENDENCIES
   zeus
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -8,3 +8,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'bootsnap/setup'


### PR DESCRIPTION
Add bootsnap to gemfile to improve boot times / reduce test run by 3 minutes (8:30 vs 11:30 previously.) Bootsnap will be the standard in Rails 5.2