### PR TITLE
Cleanup: Use Ruby style guide syntax for arrays (extracted from Rubocop PR)

### DIFF
--- a/app/controllers/admin/fields_controller.rb
+++ b/app/controllers/admin/fields_controller.rb
@@ -6,7 +6,7 @@
 class Admin::FieldsController < Admin::ApplicationController
   before_action "set_current_tab('admin/fields')", only: [:index]
 
-  load_resource except: [:create, :subform]
+  load_resource except: %i[create subform]
 
   # GET /fields
   # GET /fields.xml                                                      HTML

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -4,7 +4,7 @@
 # See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
 class Admin::GroupsController < Admin::ApplicationController
-  before_action :setup_current_tab, only: [:index, :show]
+  before_action :setup_current_tab, only: %i[index show]
 
   load_resource
 

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -4,7 +4,7 @@
 # See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
 class Admin::TagsController < Admin::ApplicationController
-  before_action "set_current_tab('admin/tags')", only: [:index, :show]
+  before_action "set_current_tab('admin/tags')", only: %i[index show]
 
   load_resource
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,7 +4,7 @@
 # See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
 class Admin::UsersController < Admin::ApplicationController
-  before_action :setup_current_tab, only: [:index, :show]
+  before_action :setup_current_tab, only: %i[index show]
 
   load_resource except: [:create]
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
   helper_method :called_from_index_page?, :called_from_landing_page?
   helper_method :klass
 
-  respond_to :html, only: [:index, :show, :auto_complete]
+  respond_to :html, only: %i[index show auto_complete]
   respond_to :js
   respond_to :json, :xml, except: :edit
   respond_to :atom, :csv, :rss, :xls, only: :index

--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -4,7 +4,7 @@
 # See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
 class AuthenticationsController < ApplicationController
-  before_action :require_no_user, only: [:new, :create, :show]
+  before_action :require_no_user, only: %i[new create show]
   before_action :require_user, only: :destroy
 
   #----------------------------------------------------------------------------

--- a/app/controllers/entities/contacts_controller.rb
+++ b/app/controllers/entities/contacts_controller.rb
@@ -4,7 +4,7 @@
 # See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
 class ContactsController < EntitiesController
-  before_action :get_accounts, only: [:new, :create, :edit, :update]
+  before_action :get_accounts, only: %i[new create edit update]
 
   # GET /contacts
   #----------------------------------------------------------------------------

--- a/app/controllers/entities/opportunities_controller.rb
+++ b/app/controllers/entities/opportunities_controller.rb
@@ -6,7 +6,7 @@
 class OpportunitiesController < EntitiesController
   before_action :load_settings
   before_action :get_data_for_sidebar, only: :index
-  before_action :set_params, only: [:index, :redraw, :filter]
+  before_action :set_params, only: %i[index redraw filter]
 
   # GET /opportunities
   #----------------------------------------------------------------------------

--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -5,8 +5,8 @@
 #------------------------------------------------------------------------------
 class EntitiesController < ApplicationController
   before_action :require_user
-  before_action :set_current_tab, only: [:index, :show]
-  before_action :set_view, only: [:index, :show, :redraw]
+  before_action :set_current_tab, only: %i[index show]
+  before_action :set_view, only: %i[index show redraw]
 
   before_action :set_options, only: :index
   before_action :load_ransack_search, only: :index

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,7 +4,7 @@
 # See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
 class HomeController < ApplicationController
-  before_action :require_user, except: [:toggle, :timezone]
+  before_action :require_user, except: %i[toggle timezone]
   before_action :set_current_tab, only: :index
 
   #----------------------------------------------------------------------------
@@ -57,9 +57,9 @@ class HomeController < ApplicationController
   #----------------------------------------------------------------------------
   def timeline
     state = params[:state].to_s
-    if %w(Collapsed Expanded).include?(state)
+    if %w[Collapsed Expanded].include?(state)
       if (model_type = params[:type].to_s).present?
-        if %w(comment email).include?(model_type)
+        if %w[comment email].include?(model_type)
           model = model_type.camelize.constantize
           item = model.find(params[:id])
           item.update_attribute(:state, state)
@@ -115,7 +115,7 @@ class HomeController < ApplicationController
   def activity_event
     event = current_user.pref[:activity_event]
     if event == "all_events"
-      %w(create update destroy)
+      %w[create update destroy]
     else
       event
     end
@@ -155,8 +155,8 @@ class HomeController < ApplicationController
     duration = current_user.pref[:activity_duration]
     if duration
       words = duration.split("_") # "two_weeks" => 2.weeks
-      if %w(one two).include?(words.first) && %w(hour day days week weeks month).include?(words.last)
-        %w(zero one two).index(words.first).send(words.last)
+      if %w[one two].include?(words.first) && %w[hour day days week weeks month].include?(words.last)
+        %w[zero one two].index(words.first).send(words.last)
       end
     end
   end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -4,7 +4,7 @@
 # See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
 class PasswordsController < ApplicationController
-  before_action :load_user_using_perishable_token, only: [:edit, :update]
+  before_action :load_user_using_perishable_token, only: %i[edit update]
   before_action :require_no_user
 
   #----------------------------------------------------------------------------

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,7 +5,7 @@
 #------------------------------------------------------------------------------
 class TasksController < ApplicationController
   before_action :require_user
-  before_action :set_current_tab, only: [:index, :show]
+  before_action :set_current_tab, only: %i[index show]
   before_action :update_sidebar, only: :index
 
   # GET /tasks

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,12 +4,12 @@
 # See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
 class UsersController < ApplicationController
-  before_action :set_current_tab, only: [:show, :opportunities_overview] # Don't hightlight any tabs.
+  before_action :set_current_tab, only: %i[show opportunities_overview] # Don't hightlight any tabs.
 
   check_authorization
   load_and_authorize_resource # handles all security
 
-  respond_to :html, only: [:show, :new]
+  respond_to :html, only: %i[show new]
 
   # GET /users/1
   # GET /users/1.js

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,14 +16,14 @@ module ApplicationHelper
 
   #----------------------------------------------------------------------------
   def tabless_layout?
-    %w(authentications passwords).include?(controller.controller_name) ||
-      ((controller.controller_name == "users") && %w(create new).include?(controller.action_name))
+    %w[authentications passwords].include?(controller.controller_name) ||
+      ((controller.controller_name == "users") && %w[create new].include?(controller.action_name))
   end
 
   # Show existing flash or embed hidden paragraph ready for flash[:notice]
   #----------------------------------------------------------------------------
   def show_flash(options = { sticky: false })
-    [:error, :warning, :info, :notice].each do |type|
+    %i[error warning info notice].each do |type|
       if flash[type]
         html = content_tag(:div, h(flash[type]), id: "flash")
         flash[type] = nil
@@ -175,7 +175,7 @@ module ApplicationHelper
 
   #----------------------------------------------------------------------------
   def jumpbox(current)
-    tabs = [:campaigns, :accounts, :leads, :contacts, :opportunities]
+    tabs = %i[campaigns accounts leads contacts opportunities]
     current = tabs.first unless tabs.include?(current)
     tabs.map do |tab|
       link_to_function(t("tab_#{tab}"), "crm.jumper('#{tab}')", "html-data" => tab, class: (tab == current ? 'selected' : ''))
@@ -252,7 +252,7 @@ module ApplicationHelper
   # Display web presence mini-icons for Contact or Lead.
   #----------------------------------------------------------------------------
   def web_presence_icons(person)
-    [:blog, :linkedin, :facebook, :twitter, :skype].map do |site|
+    %i[blog linkedin facebook twitter skype].map do |site|
       url = person.send(site)
       unless url.blank?
         if site == :skype
@@ -368,15 +368,15 @@ module ApplicationHelper
     url_params[:view] = @view unless @view.blank? # tasks
     url_params[:id] = params[:id] unless params[:id].blank?
 
-    exports = %w(xls csv).map do |format|
+    exports = %w[xls csv].map do |format|
       link_to(format.upcase, url_params.merge(format: format), title: I18n.t(:"to_#{format}")) unless action.to_s == "show"
     end
 
-    feeds = %w(rss atom).map do |format|
+    feeds = %w[rss atom].map do |format|
       link_to(format.upcase, url_params.merge(format: format, authentication_credentials: token), title: I18n.t(:"to_#{format}"))
     end
 
-    links = %w(perm).map do |format|
+    links = ['perm'].map do |format|
       link_to(format.upcase, url_params, title: I18n.t(:"to_#{format}"))
     end
 

--- a/app/helpers/opportunities_helper.rb
+++ b/app/helpers/opportunities_helper.rb
@@ -17,7 +17,7 @@ module OpportunitiesHelper
     amount = []
     summary << (opportunity.stage ? t(opportunity.stage) : t(:other))
     summary << number_to_currency(opportunity.weighted_amount, precision: 0)
-    unless %w(won lost).include?(opportunity.stage)
+    unless %w[won lost].include?(opportunity.stage)
       amount << number_to_currency(opportunity.amount || 0, precision: 0)
       amount << (opportunity.discount ? t(:discount_number, number_to_currency(opportunity.discount, precision: 0)) : t(:no_discount))
       amount << t(:probability_number, (opportunity.probability || 0).to_s + '%')

--- a/app/inputs/date_pair_input.rb
+++ b/app/inputs/date_pair_input.rb
@@ -15,7 +15,7 @@ class DatePairInput < SimpleForm::Inputs::Base
     [field1, field2].compact.each do |field|
       out << '<div>'.html_safe
       label = field == field1 ? I18n.t('pair.start') : I18n.t('pair.end')
-      [:required, :disabled].each { |k| input_html_options.delete(k) } # ensure these come from field not default options
+      %i[required disabled].each { |k| input_html_options.delete(k) } # ensure these come from field not default options
       input_html_options.merge!(field.input_options)
       input_html_options[:value] = value(field)
       out << "<label#{' class="req"' if input_html_options[:required]}>#{label}</label>".html_safe

--- a/app/models/entities/account.rb
+++ b/app/models/entities/account.rb
@@ -67,7 +67,7 @@ class Account < ActiveRecord::Base
   exportable
   sortable by: ["name ASC", "rating DESC", "created_at DESC", "updated_at DESC"], default: "created_at DESC"
 
-  has_ransackable_associations %w(contacts opportunities tags activities emails addresses comments tasks)
+  has_ransackable_associations %w[contacts opportunities tags activities emails addresses comments tasks]
   ransack_can_autocomplete
 
   validates_presence_of :name, message: :missing_account_name

--- a/app/models/entities/account_contact.rb
+++ b/app/models/entities/account_contact.rb
@@ -20,7 +20,7 @@ class AccountContact < ActiveRecord::Base
   belongs_to :contact
 
   has_paper_trail class_name: 'Version', meta: { related: :contact },
-                  ignore: [:id, :created_at, :updated_at, :contact_id]
+                  ignore: %i[id created_at updated_at contact_id]
 
   validates_presence_of :account_id
 

--- a/app/models/entities/campaign.rb
+++ b/app/models/entities/campaign.rb
@@ -56,11 +56,11 @@ class Campaign < ActiveRecord::Base
   exportable
   sortable by: ["name ASC", "target_leads DESC", "target_revenue DESC", "leads_count DESC", "revenue DESC", "starts_on DESC", "ends_on DESC", "created_at DESC", "updated_at DESC"], default: "created_at DESC"
 
-  has_ransackable_associations %w(leads opportunities tags activities emails comments tasks)
+  has_ransackable_associations %w[leads opportunities tags activities emails comments tasks]
   ransack_can_autocomplete
 
   validates_presence_of :name, message: :missing_campaign_name
-  validates_uniqueness_of :name, scope: [:user_id, :deleted_at]
+  validates_uniqueness_of :name, scope: %i[user_id deleted_at]
   validate :start_and_end_dates
   validate :users_for_shared_access
   validates :status, inclusion: { in: proc { Setting.unroll(:campaign_status).map { |s| s.last.to_s } } }, allow_blank: true

--- a/app/models/entities/contact.rb
+++ b/app/models/entities/contact.rb
@@ -52,7 +52,7 @@ class Contact < ActiveRecord::Base
 
   delegate :campaign, to: :lead, allow_nil: true
 
-  has_ransackable_associations %w(account opportunities tags activities emails addresses comments tasks)
+  has_ransackable_associations %w[account opportunities tags activities emails addresses comments tasks]
   ransack_can_autocomplete
 
   serialize :subscribed_users, Set
@@ -162,7 +162,7 @@ class Contact < ActiveRecord::Base
       assigned_to: params[:account][:assigned_to],
       access:      params[:access]
     }
-    %w(first_name last_name title source email alt_email phone mobile blog linkedin facebook twitter skype do_not_call background_info).each do |name|
+    %w[first_name last_name title source email alt_email phone mobile blog linkedin facebook twitter skype do_not_call background_info].each do |name|
       attributes[name] = model.send(name.intern)
     end
 

--- a/app/models/entities/lead.rb
+++ b/app/models/entities/lead.rb
@@ -69,7 +69,7 @@ class Lead < ActiveRecord::Base
   exportable
   sortable by: ["first_name ASC", "last_name ASC", "company ASC", "rating DESC", "created_at DESC", "updated_at DESC"], default: "created_at DESC"
 
-  has_ransackable_associations %w(contact campaign tasks tags activities emails addresses comments)
+  has_ransackable_associations %w[contact campaign tasks tags activities emails addresses comments]
   ransack_can_autocomplete
 
   validates_presence_of :first_name, message: :missing_first_name, if: -> { Setting.require_first_names }

--- a/app/models/entities/opportunity.rb
+++ b/app/models/entities/opportunity.rb
@@ -75,11 +75,11 @@ class Opportunity < ActiveRecord::Base
   exportable
   sortable by: ["name ASC", "amount DESC", "amount*probability DESC", "probability DESC", "closes_on ASC", "created_at DESC", "updated_at DESC"], default: "created_at DESC"
 
-  has_ransackable_associations %w(account contacts tags campaign activities emails comments)
+  has_ransackable_associations %w[account contacts tags campaign activities emails comments]
   ransack_can_autocomplete
 
   validates_presence_of :name, message: :missing_opportunity_name
-  validates_numericality_of [:probability, :amount, :discount], allow_nil: true
+  validates_numericality_of %i[probability amount discount], allow_nil: true
   validate :users_for_shared_access
   validates :stage, inclusion: { in: proc { Setting.unroll(:opportunity_stage).map { |s| s.last.to_s } } }, allow_blank: true
 

--- a/app/models/fields/custom_field.rb
+++ b/app/models/fields/custom_field.rb
@@ -54,7 +54,7 @@ class CustomField < Field
   after_create :add_ransack_translation
 
   SAFE_DB_TRANSITIONS = {
-    any: [%w(date time timestamp), %w(integer float)],
+    any: [%w[date time timestamp], %w[integer float]],
     one: { 'string' => 'text' }
   }
 

--- a/app/models/fields/custom_field_pair.rb
+++ b/app/models/fields/custom_field_pair.rb
@@ -12,7 +12,7 @@ class CustomFieldPair < CustomField
     fields = params['field']
     as = params['field']['as']
     pair = params.delete('pair')
-    base_params = fields.delete_if { |k, _v| !%w(field_group_id label as).include?(k) }
+    base_params = fields.delete_if { |k, _v| !%w[field_group_id label as].include?(k) }
     klass = ("custom_field_" + as.gsub('pair', '_pair')).classify.constantize
     field1 = klass.create(base_params.merge(pair['0']))
     field2 = klass.create(base_params.merge(pair['1']).merge('pair_id' => field1.id, 'required' => field1.required, 'disabled' => field1.disabled))
@@ -24,7 +24,7 @@ class CustomFieldPair < CustomField
   def self.update_pair(params)
     fields = params['field']
     pair = params.delete('pair')
-    base_params = fields.delete_if { |k, _v| !%w(field_group_id label as).include?(k) }
+    base_params = fields.delete_if { |k, _v| !%w[field_group_id label as].include?(k) }
     field1 = CustomFieldPair.find(params['id'])
     field1.update_attributes(base_params.merge(pair['0']))
     field2 = field1.paired_with

--- a/app/models/fields/field.rb
+++ b/app/models/fields/field.rb
@@ -69,7 +69,7 @@ class Field < ActiveRecord::Base
   def input_options
     input_html = {}
     attributes.reject do |k, v|
-      !%w(as collection disabled label placeholder required maxlength).include?(k) || v.blank?
+      !%w[as collection disabled label placeholder required maxlength].include?(k) || v.blank?
     end.symbolize_keys.merge(input_html)
   end
 

--- a/app/models/polymorphic/address.rb
+++ b/app/models/polymorphic/address.rb
@@ -36,7 +36,7 @@ class Address < ActiveRecord::Base
   #----------------------------------------------------------------------------
   def blank?
     if Setting.compound_address
-      %w(street1 street2 city state zipcode country).all? { |attr| send(attr).blank? }
+      %w[street1 street2 city state zipcode country].all? { |attr| send(attr).blank? }
     else
       full_address.blank?
     end
@@ -50,7 +50,7 @@ class Address < ActiveRecord::Base
   #   accepts_nested_attributes_for :business_address, :allow_destroy => true, :reject_if => proc {|attributes| Address.reject_address(attributes)}
   def self.reject_address(attributes)
     exists = attributes['id'].present?
-    empty = %w(street1 street2 city state zipcode country full_address).map { |name| attributes[name].blank? }.all?
+    empty = %w[street1 street2 city state zipcode country full_address].map { |name| attributes[name].blank? }.all?
     attributes[:_destroy] = 1 if exists && empty
     (!exists && empty)
   end

--- a/app/models/polymorphic/avatar.rb
+++ b/app/models/polymorphic/avatar.rb
@@ -36,7 +36,7 @@ class Avatar < ActiveRecord::Base
   end
   has_attached_file :image, styles: STYLES.dup, url: "/avatars/:entity_type/:id/:style_:filename", default_url: "/assets/avatar.jpg"
   validates_attachment :image, presence: true,
-                               content_type: { content_type: %w(image/jpeg image/jpg image/png image/gif) }
+                               content_type: { content_type: ['image/jpeg', 'image/jpg', 'image/png', 'image/gif'] }
 
   # Convert STYLE symbols to 'w x h' format for Gravatar and Rails
   # e.g. Avatar.size_from_style(:size => :large) -> '75x75'
@@ -44,7 +44,7 @@ class Avatar < ActiveRecord::Base
   #----------------------------------------------------------------------------
   def self.size_from_style!(options)
     if options[:width] && options[:height]
-      options[:size] = [:width, :height].map { |d| options[d] }.join("x")
+      options[:size] = %i[width height].map { |d| options[d] }.join("x")
       options.delete(:width)
       options.delete(:height)
     elsif Avatar::STYLES.keys.include?(options[:size])

--- a/app/models/polymorphic/task.rb
+++ b/app/models/polymorphic/task.rb
@@ -29,7 +29,7 @@ class Task < ActiveRecord::Base
   include ActiveModel::Serializers::Xml
 
   attr_accessor :calendar
-  ALLOWED_VIEWS = %w(pending assigned completed)
+  ALLOWED_VIEWS = %w[pending assigned completed]
 
   belongs_to :user
   belongs_to :assignee, class_name: "User", foreign_key: :assigned_to

--- a/app/models/polymorphic/version.rb
+++ b/app/models/polymorphic/version.rb
@@ -6,9 +6,9 @@
 require 'paper_trail'
 
 class Version < PaperTrail::Version
-  ASSETS = %w(all tasks campaigns leads accounts contacts opportunities comments emails)
-  EVENTS = %w(all_events create view update destroy)
-  DURATION = %w(one_hour one_day two_days one_week two_weeks one_month)
+  ASSETS = %w[all tasks campaigns leads accounts contacts opportunities comments emails]
+  EVENTS = %w[all_events create view update destroy]
+  DURATION = %w[one_hour one_day two_days one_week two_weeks one_month]
 
   belongs_to :related, polymorphic: true
   belongs_to :user, foreign_key: :whodunnit

--- a/app/models/users/user.rb
+++ b/app/models/users/user.rb
@@ -159,7 +159,7 @@ class User < ActiveRecord::Base
   # Prevent deleting a user unless she has no artifacts left.
   #----------------------------------------------------------------------------
   def has_related_assets?
-    sum = %w(Account Campaign Lead Contact Opportunity Comment Task).detect do |asset|
+    sum = %w[Account Campaign Lead Contact Opportunity Comment Task].detect do |asset|
       klass = asset.constantize
 
       asset != "Comment" && klass.assigned_to(self).exists? || klass.created_by(self).exists?
@@ -177,7 +177,7 @@ class User < ActiveRecord::Base
     end
 
     def can_signup?
-      [:allowed, :needs_approval].include? Setting.user_signup
+      %i[allowed needs_approval].include? Setting.user_signup
     end
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -67,7 +67,7 @@ module FatFreeCRM
     config.encoding = "utf-8"
 
     # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += [:password, :password_hash, :password_salt, :password_confirmation]
+    config.filter_parameters += %i[password password_hash password_salt password_confirmation]
   end
 end
 

--- a/config/deploy.example.rb
+++ b/config/deploy.example.rb
@@ -29,7 +29,7 @@ set :repo_url, 'git://github.com/fatfreecrm/fat_free_crm.git'
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w(config/database.yml config/settings.yml)
+set :linked_files, ['config/database.yml', 'config/settings.yml']
 
 # Default value for linked_dirs is []
 # set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,7 +13,7 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w(print.css chosen-sprite.png jquery-ui/* jquery_ui_datepicker/*.js)
+Rails.application.config.assets.precompile += ['print.css', 'chosen-sprite.png', 'jquery-ui/*', 'jquery_ui_datepicker/*.js']
 
 # Don't initialize Rails environment
 Rails.application.config.assets.initialize_on_precompile = false

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -3,4 +3,4 @@
 # Fat Free CRM is freely distributable under the terms of MIT license.
 # See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
-ENTITIES = %w(Account Campaign Contact Lead Opportunity).freeze
+ENTITIES = %w[Account Campaign Contact Lead Opportunity].freeze

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -6,9 +6,9 @@
 Ransack.configure do |config|
   config.default_predicates = {
     compounds: true,
-    only: [
-      :cont, :not_cont, :blank, :present, :true, :false, :eq, :not_eq,
-      :lt, :gt, :null, :not_null, :matches, :does_not_match
+    only: %i[
+      cont not_cont blank present true false eq not_eq
+      lt gt null not_null matches does_not_match
     ]
   }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,14 +17,14 @@ Rails.application.routes.draw do
 
   get '/home/options',  as: :options
   get '/home/toggle',   as: :toggle
-  match '/home/timeline', as: :timeline, via: [:get, :put, :post]
-  match '/home/timezone', as: :timezone, via: [:get, :put, :post]
+  match '/home/timeline', as: :timeline, via: %i[get put post]
+  match '/home/timezone', as: :timezone, via: %i[get put post]
   post '/home/redraw',   as: :redraw
 
-  resource :authentication, except: [:index, :edit]
-  resources :comments,       except: [:new, :show]
+  resource :authentication, except: %i[index edit]
+  resources :comments,       except: %i[new show]
   resources :emails,         only: [:destroy]
-  resources :passwords,      only: [:new, :create, :edit, :update]
+  resources :passwords,      only: %i[new create edit update]
 
   resources :accounts, id: /\d+/ do
     collection do
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
       post :filter
       get :options
       get :field_group
-      match :auto_complete, via: [:get, :post]
+      match :auto_complete, via: %i[get post]
       get :redraw
       get :versions
     end
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
       post :filter
       get :options
       get :field_group
-      match :auto_complete, via: [:get, :post]
+      match :auto_complete, via: %i[get post]
       get :redraw
       get :versions
     end
@@ -72,7 +72,7 @@ Rails.application.routes.draw do
       post :filter
       get :options
       get :field_group
-      match :auto_complete, via: [:get, :post]
+      match :auto_complete, via: %i[get post]
       get :redraw
       get :versions
     end
@@ -91,7 +91,7 @@ Rails.application.routes.draw do
       post :filter
       get :options
       get :field_group
-      match :auto_complete, via: [:get, :post]
+      match :auto_complete, via: %i[get post]
       get :redraw
       get :versions
       get :autocomplete_account_name
@@ -102,7 +102,7 @@ Rails.application.routes.draw do
       post :subscribe
       post :unsubscribe
       put :attach
-      match :promote, via: [:patch, :put]
+      match :promote, via: %i[patch put]
       put :reject
     end
   end
@@ -113,7 +113,7 @@ Rails.application.routes.draw do
       post :filter
       get :options
       get :field_group
-      match :auto_complete, via: [:get, :post]
+      match :auto_complete, via: %i[get post]
       get :redraw
       get :versions
     end
@@ -129,7 +129,7 @@ Rails.application.routes.draw do
   resources :tasks, id: /\d+/ do
     collection do
       post :filter
-      match :auto_complete, via: [:get, :post]
+      match :auto_complete, via: %i[get post]
     end
     member do
       put :complete
@@ -137,16 +137,16 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :users, id: /\d+/, except: [:index, :destroy] do
+  resources :users, id: /\d+/, except: %i[index destroy] do
     member do
       get :avatar
       get :password
-      match :upload_avatar, via: [:put, :patch]
+      match :upload_avatar, via: %i[put patch]
       patch :change_password
       post :redraw
     end
     collection do
-      match :auto_complete, via: [:get, :post]
+      match :auto_complete, via: %i[get post]
       get :opportunities_overview
     end
   end
@@ -156,7 +156,7 @@ Rails.application.routes.draw do
 
     resources :users do
       collection do
-        match :auto_complete, via: [:get, :post]
+        match :auto_complete, via: %i[get post]
       end
       member do
         get :confirm
@@ -165,7 +165,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :field_groups, except: [:index, :show] do
+    resources :field_groups, except: %i[index show] do
       collection do
         post :sort
       end
@@ -176,7 +176,7 @@ Rails.application.routes.draw do
 
     resources :fields do
       collection do
-        match :auto_complete, via: [:get, :post]
+        match :auto_complete, via: %i[get post]
         get :options
         get :redraw
         post :sort

--- a/db/migrate/20100928030599_create_users.rb
+++ b/db/migrate/20100928030599_create_users.rb
@@ -32,7 +32,7 @@ class CreateUsers < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :users, [:username, :deleted_at], unique: true
+    add_index :users, %i[username deleted_at], unique: true
     add_index :users, :email
     add_index :users, :last_request_at
     add_index :users, :remember_token

--- a/db/migrate/20100928030601_create_accounts.rb
+++ b/db/migrate/20100928030601_create_accounts.rb
@@ -16,7 +16,7 @@ class CreateAccounts < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :accounts, [:user_id, :name, :deleted_at], unique: true
+    add_index :accounts, %i[user_id name deleted_at], unique: true
     add_index :accounts, :assigned_to
   end
 

--- a/db/migrate/20100928030604_create_preferences.rb
+++ b/db/migrate/20100928030604_create_preferences.rb
@@ -6,7 +6,7 @@ class CreatePreferences < ActiveRecord::Migration
       t.text :value
       t.timestamps
     end
-    add_index :preferences, [:user_id, :name]
+    add_index :preferences, %i[user_id name]
   end
 
   def self.down

--- a/db/migrate/20100928030605_create_campaigns.rb
+++ b/db/migrate/20100928030605_create_campaigns.rb
@@ -24,7 +24,7 @@ class CreateCampaigns < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :campaigns, [:user_id, :name, :deleted_at], unique: true
+    add_index :campaigns, %i[user_id name deleted_at], unique: true
     add_index :campaigns, :assigned_to
   end
 

--- a/db/migrate/20100928030606_create_leads.rb
+++ b/db/migrate/20100928030606_create_leads.rb
@@ -28,7 +28,7 @@ class CreateLeads < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :leads, [:user_id, :last_name, :deleted_at], unique: true
+    add_index :leads, %i[user_id last_name deleted_at], unique: true
     add_index :leads, :assigned_to
   end
 

--- a/db/migrate/20100928030607_create_contacts.rb
+++ b/db/migrate/20100928030607_create_contacts.rb
@@ -28,7 +28,7 @@ class CreateContacts < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :contacts, [:user_id, :last_name, :deleted_at], unique: true, name: 'id_last_name_deleted'
+    add_index :contacts, %i[user_id last_name deleted_at], unique: true, name: 'id_last_name_deleted'
     add_index :contacts, :assigned_to
   end
 

--- a/db/migrate/20100928030608_create_opportunities.rb
+++ b/db/migrate/20100928030608_create_opportunities.rb
@@ -17,7 +17,7 @@ class CreateOpportunities < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :opportunities, [:user_id, :name, :deleted_at], unique: true, name: 'id_name_deleted'
+    add_index :opportunities, %i[user_id name deleted_at], unique: true, name: 'id_name_deleted'
     add_index :opportunities, :assigned_to
   end
 

--- a/db/migrate/20100928030612_create_tasks.rb
+++ b/db/migrate/20100928030612_create_tasks.rb
@@ -16,7 +16,7 @@ class CreateTasks < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :tasks, [:user_id, :name, :deleted_at], unique: true
+    add_index :tasks, %i[user_id name deleted_at], unique: true
     add_index :tasks, :assigned_to
   end
 

--- a/db/migrate/20100928030620_remove_uuid.rb
+++ b/db/migrate/20100928030620_remove_uuid.rb
@@ -2,7 +2,7 @@ class RemoveUuid < ActiveRecord::Migration
   @@uuid_configured = false
 
   def self.up
-    [:users, :accounts, :campaigns, :leads, :contacts, :opportunities, :tasks].each do |table|
+    %i[users accounts campaigns leads contacts opportunities tasks].each do |table|
       remove_column table, :uuid
       execute("DROP TRIGGER IF EXISTS #{table}_uuid") if uuid_configured?
     end

--- a/db/migrate/20100928030623_create_addresses.rb
+++ b/db/migrate/20100928030623_create_addresses.rb
@@ -16,7 +16,7 @@ class CreateAddresses < ActiveRecord::Migration
       t.datetime :deleted_at
     end
 
-    add_index :addresses, [:addressable_id, :addressable_type]
+    add_index :addresses, %i[addressable_id addressable_type]
 
     # Migrate data from assets to Address table into full_address blob
     Contact.all.each do |asset|

--- a/db/migrate/20100928030624_add_index_on_permissions.rb
+++ b/db/migrate/20100928030624_add_index_on_permissions.rb
@@ -1,9 +1,9 @@
 class AddIndexOnPermissions < ActiveRecord::Migration
   def self.up
-    add_index :permissions, [:asset_id, :asset_type]
+    add_index :permissions, %i[asset_id asset_type]
   end
 
   def self.down
-    remove_index :permissions, [:asset_id, :asset_type]
+    remove_index :permissions, %i[asset_id asset_type]
   end
 end

--- a/db/migrate/20100928030625_create_emails.rb
+++ b/db/migrate/20100928030625_create_emails.rb
@@ -17,7 +17,7 @@ class CreateEmails < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :emails, [:mediator_id, :mediator_type]
+    add_index :emails, %i[mediator_id mediator_type]
   end
 
   def self.down

--- a/db/migrate/20100928030627_acts_as_taggable_on_migration.rb
+++ b/db/migrate/20100928030627_acts_as_taggable_on_migration.rb
@@ -19,7 +19,7 @@ class ActsAsTaggableOnMigration < ActiveRecord::Migration
     end
 
     add_index :taggings, :tag_id
-    add_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings, %i[taggable_id taggable_type context]
   end
 
   def self.down

--- a/db/migrate/20111201030535_add_field_groups_klass_name.rb
+++ b/db/migrate/20111201030535_add_field_groups_klass_name.rb
@@ -3,7 +3,7 @@ class AddFieldGroupsKlassName < ActiveRecord::Migration
     add_column :field_groups, :klass_name, :string, limit: 32
 
     # Add a default field group for each model
-    %w(Account Campaign Contact Lead Opportunity).each do |entity|
+    %w[Account Campaign Contact Lead Opportunity].each do |entity|
       klass = entity.classify.constantize
       field_group = FieldGroup.new
       field_group.label = 'Custom Fields'

--- a/db/migrate/20120216031616_create_versions.rb
+++ b/db/migrate/20120216031616_create_versions.rb
@@ -8,11 +8,11 @@ class CreateVersions < ActiveRecord::Migration
       t.text :object
       t.datetime :created_at
     end
-    add_index :versions, [:item_type, :item_id]
+    add_index :versions, %i[item_type item_id]
   end
 
   def self.down
-    remove_index :versions, [:item_type, :item_id]
+    remove_index :versions, %i[item_type item_id]
     drop_table :versions
   end
 end

--- a/db/migrate/20120314080441_add_subscribed_users_to_entities.rb
+++ b/db/migrate/20120314080441_add_subscribed_users_to_entities.rb
@@ -1,6 +1,6 @@
 class AddSubscribedUsersToEntities < ActiveRecord::Migration
   def change
-    %w(accounts campaigns contacts leads opportunities tasks).each do |table|
+    %w[accounts campaigns contacts leads opportunities tasks].each do |table|
       add_column table.to_sym, :subscribed_users, :text
       # Reset the column information of each model
       table.singularize.capitalize.constantize.reset_column_information

--- a/db/migrate/20120405080742_change_further_subscribed_users_to_set.rb
+++ b/db/migrate/20120405080742_change_further_subscribed_users_to_set.rb
@@ -1,7 +1,7 @@
 class ChangeFurtherSubscribedUsersToSet < ActiveRecord::Migration
   def up
     # Change the other tables that were missing from the previous migration
-    %w(campaigns opportunities leads tasks accounts).each do |table|
+    %w[campaigns opportunities leads tasks accounts].each do |table|
       entities = connection.select_all %(
         SELECT id, subscribed_users
         FROM #{table}

--- a/db/migrate/20120406082136_create_groups.rb
+++ b/db/migrate/20120406082136_create_groups.rb
@@ -14,6 +14,6 @@ class CreateGroups < ActiveRecord::Migration
     end
     add_index :groups_users, :group_id
     add_index :groups_users, :user_id
-    add_index :groups_users, [:group_id, :user_id]
+    add_index :groups_users, %i[group_id user_id]
   end
 end

--- a/db/migrate/20120510025219_add_not_null_constraints_for_timestamp_columns.rb
+++ b/db/migrate/20120510025219_add_not_null_constraints_for_timestamp_columns.rb
@@ -12,8 +12,8 @@ class AddNotNullConstraintsForTimestampColumns < ActiveRecord::Migration
   def set_timestamp_constraints(constraints)
     ActiveRecord::Base.connection.tables.each do |table|
       # If table has both timestamp columns, set not null constraints on both columns.
-      if [:created_at, :updated_at].all? { |column| column_exists?(table, column) }
-        [:created_at, :updated_at].each do |column|
+      if %i[created_at updated_at].all? { |column| column_exists?(table, column) }
+        %i[created_at updated_at].each do |column|
           change_column table, column, :datetime, constraints
         end
       end

--- a/db/migrate/20140916012922_add_indexes_to_model_associations.rb
+++ b/db/migrate/20140916012922_add_indexes_to_model_associations.rb
@@ -1,6 +1,6 @@
 class AddIndexesToModelAssociations < ActiveRecord::Migration
   def change
-    add_index :contact_opportunities, [:contact_id, :opportunity_id]
-    add_index :account_opportunities, [:account_id, :opportunity_id]
+    add_index :contact_opportunities, %i[contact_id opportunity_id]
+    add_index :account_opportunities, %i[account_id opportunity_id]
   end
 end

--- a/db/migrate/20141230205453_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20141230205453_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -4,9 +4,9 @@ class AddMissingUniqueIndices < ActiveRecord::Migration
     add_index :tags, :name, unique: true
 
     remove_index :taggings, :tag_id
-    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    remove_index :taggings, %i[taggable_id taggable_type context]
     add_index :taggings,
-              [:tag_id, :taggable_id, :taggable_type, :context],
+              %i[tag_id taggable_id taggable_type context],
               unique: true, name: 'taggings_idx'
   end
 
@@ -15,6 +15,6 @@ class AddMissingUniqueIndices < ActiveRecord::Migration
 
     remove_index :taggings, name: 'taggings_idx'
     add_index :taggings, :tag_id
-    add_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings, %i[taggable_id taggable_type context]
   end
 end

--- a/db/migrate/20141230205455_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20141230205455_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,10 +1,10 @@
 # This migration comes from acts_as_taggable_on_engine (originally 4)
 class AddMissingTaggableIndex < ActiveRecord::Migration
   def self.up
-    add_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings, %i[taggable_id taggable_type context]
   end
 
   def self.down
-    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    remove_index :taggings, %i[taggable_id taggable_type context]
   end
 end

--- a/db/migrate/20150427131956_create_index_related_type.rb
+++ b/db/migrate/20150427131956_create_index_related_type.rb
@@ -1,9 +1,9 @@
 class CreateIndexRelatedType < ActiveRecord::Migration
   def up
-    add_index :versions, [:related_id, :related_type]
+    add_index :versions, %i[related_id related_type]
   end
 
   def down
-    remove_index :versions, [:related_id, :related_type]
+    remove_index :versions, %i[related_id related_type]
   end
 end

--- a/db/migrate/20160511053730_add_account_contacts_index.rb
+++ b/db/migrate/20160511053730_add_account_contacts_index.rb
@@ -1,5 +1,5 @@
 class AddAccountContactsIndex < ActiveRecord::Migration
   def change
-    add_index :account_contacts, [:account_id, :contact_id]
+    add_index :account_contacts, %i[account_id contact_id]
   end
 end

--- a/lib/fat_free_crm/engine.rb
+++ b/lib/fat_free_crm/engine.rb
@@ -8,8 +8,8 @@ module FatFreeCRM
     config.autoload_paths += Dir[root.join("app/models/**")] +
                              Dir[root.join("app/controllers/entities")]
 
-    config.active_record.observers = [:lead_observer, :opportunity_observer,
-                                      :task_observer, :entity_observer]
+    config.active_record.observers = %i[lead_observer opportunity_observer
+                                        task_observer entity_observer]
 
     initializer "model_core.factories", after: "factory_girl.set_factory_paths" do
       FactoryGirl.definition_file_paths << File.expand_path('../../../spec/factories', __FILE__) if defined?(FactoryGirl)

--- a/lib/fat_free_crm/mail_processor/base.rb
+++ b/lib/fat_free_crm/mail_processor/base.rb
@@ -12,7 +12,7 @@ require 'nokogiri'
 module FatFreeCRM
   module MailProcessor
     class Base
-      KEYWORDS = %w(account campaign contact lead opportunity).freeze
+      KEYWORDS = %w[account campaign contact lead opportunity].freeze
 
       #--------------------------------------------------------------------------------------
       def initialize
@@ -94,7 +94,7 @@ module FatFreeCRM
 
       #--------------------------------------------------------------------------------------
       def with_new_emails
-        @imap.uid_search(%w(NOT SEEN)).each do |uid|
+        @imap.uid_search(%w[NOT SEEN]).each do |uid|
           begin
             email = Mail.new(@imap.uid_fetch(uid, 'RFC822').first.attr['RFC822'])
             log "fetched new message...", email
@@ -104,7 +104,7 @@ module FatFreeCRM
               discard(uid)
             end
           rescue Exception => e
-            if %w(test development).include?(Rails.env)
+            if %w[test development].include?(Rails.env)
               $stderr.puts e
               $stderr.puts e.backtrace
             end
@@ -184,7 +184,7 @@ module FatFreeCRM
       # Centralized logging.
       #--------------------------------------------------------------------------------------
       def log(message, email = nil)
-        unless %w(test cucumber).include?(Rails.env)
+        unless %w[test cucumber].include?(Rails.env)
           klass = self.class.to_s.split("::").last
           klass << " [Dry Run]" if @dry_run
           puts "[#{Time.now.rfc822}] #{klass}: #{message}"

--- a/lib/fat_free_crm/mail_processor/dropbox.rb
+++ b/lib/fat_free_crm/mail_processor/dropbox.rb
@@ -8,7 +8,7 @@ require 'fat_free_crm/mail_processor/base'
 module FatFreeCRM
   module MailProcessor
     class Dropbox < Base
-      KEYWORDS = %w(account campaign contact lead opportunity).freeze
+      KEYWORDS = %w[account campaign contact lead opportunity].freeze
 
       #--------------------------------------------------------------------------------------
       def initialize

--- a/lib/fat_free_crm/permissions.rb
+++ b/lib/fat_free_crm/permissions.rb
@@ -33,7 +33,7 @@ module FatFreeCRM
     module InstanceMethods
       # Save shared permissions to the model, if any.
       #--------------------------------------------------------------------------
-      %w(group user).each do |model|
+      %w[group user].each do |model|
         class_eval %{
 
           def #{model}_ids=(value)

--- a/lib/tasks/ffcrm/demo.rake
+++ b/lib/tasks/ffcrm/demo.rake
@@ -22,7 +22,7 @@ namespace :ffcrm do
       # Simulate random user activities.
       $stdout.sync = true
       puts "Generating user activities..."
-      %w(Account Address Campaign Comment Contact Email Lead Opportunity Task).map do |model|
+      %w[Account Address Campaign Comment Contact Email Lead Opportunity Task].map do |model|
         model.constantize.all
       end.flatten.each do |item|
         user = if item.respond_to?(:user)

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -6,7 +6,7 @@
 require 'spec_helper'
 
 describe CommentsController do
-  COMMENTABLE = [:account, :campaign, :contact, :lead, :opportunity].freeze
+  COMMENTABLE = %i[account campaign contact lead opportunity].freeze
 
   before(:each) do
     require_user

--- a/spec/controllers/emails_controller_spec.rb
+++ b/spec/controllers/emails_controller_spec.rb
@@ -6,7 +6,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe EmailsController, "handling GET /emails" do
-  MEDIATOR = [:account, :campaign, :contact, :lead, :opportunity].freeze
+  MEDIATOR = %i[account campaign contact lead opportunity].freeze
 
   before(:each) do
     require_user

--- a/spec/controllers/entities/accounts_controller_spec.rb
+++ b/spec/controllers/entities/accounts_controller_spec.rb
@@ -38,7 +38,7 @@ describe AccountsController do
     end
 
     it "should filter out accounts by category" do
-      categories = %w(customer vendor)
+      categories = %w[customer vendor]
       controller.session[:accounts_filter] = categories.join(',')
       @accounts = [
         FactoryGirl.create(:account, user: current_user, category: categories.first),

--- a/spec/controllers/entities/campaigns_controller_spec.rb
+++ b/spec/controllers/entities/campaigns_controller_spec.rb
@@ -51,7 +51,7 @@ describe CampaignsController do
       get :index
       # Note: can't compare campaigns directly because of BigDecimal objects.
       expect(assigns[:campaigns].size).to eq(2)
-      expect(assigns[:campaigns].map(&:status).sort).to eq(%w(planned started))
+      expect(assigns[:campaigns].map(&:status).sort).to eq(%w[planned started])
     end
 
     it "should perform lookup using query string" do
@@ -371,7 +371,7 @@ describe CampaignsController do
         he  = FactoryGirl.create(:user, id: 7)
         she = FactoryGirl.create(:user, id: 8)
 
-        put :update, params: { id: 42, campaign: { name: "Hello", access: "Shared", user_ids: %w(7 8) } }, xhr: true
+        put :update, params: { id: 42, campaign: { name: "Hello", access: "Shared", user_ids: %w[7 8] } }, xhr: true
         expect(assigns[:campaign].access).to eq("Shared")
         expect(assigns[:campaign].user_ids.sort).to eq([he.id, she.id])
       end

--- a/spec/controllers/entities/leads_controller_spec.rb
+++ b/spec/controllers/entities/leads_controller_spec.rb
@@ -44,7 +44,7 @@ describe LeadsController do
       get :index
       # Note: can't compare campaigns directly because of BigDecimals.
       expect(assigns[:leads].size).to eq(2)
-      expect(assigns[:leads].map(&:status).sort).to eq(%w(contacted new))
+      expect(assigns[:leads].map(&:status).sort).to eq(%w[contacted new])
     end
 
     it "should perform lookup using query string" do
@@ -335,12 +335,12 @@ describe LeadsController do
         @lead = FactoryGirl.build(:lead, campaign: @campaign, user: current_user, access: "Shared")
         allow(Lead).to receive(:new).and_return(@lead)
 
-        post :create, params: { lead: { first_name: "Billy", last_name: "Bones", access: "Campaign", user_ids: %w(7 8) }, campaign: @campaign.id }, xhr: true
+        post :create, params: { lead: { first_name: "Billy", last_name: "Bones", access: "Campaign", user_ids: %w[7 8] }, campaign: @campaign.id }, xhr: true
         expect(assigns(:lead)).to eq(@lead)
         expect(@lead.reload.access).to eq("Shared")
         expect(@lead.permissions.map(&:user_id).sort).to eq([7, 8])
         expect(@lead.permissions.map(&:asset_id)).to eq([@lead.id, @lead.id])
-        expect(@lead.permissions.map(&:asset_type)).to eq(%w(Lead Lead))
+        expect(@lead.permissions.map(&:asset_type)).to eq(%w[Lead Lead])
       end
 
       it "should get the data to update leads sidebar if called from leads index" do
@@ -466,7 +466,7 @@ describe LeadsController do
         he  = FactoryGirl.create(:user, id: 7)
         she = FactoryGirl.create(:user, id: 8)
 
-        put :update, params: { id: @lead.id, lead: { access: "Shared", user_ids: %w(7 8) } }, xhr: true
+        put :update, params: { id: @lead.id, lead: { access: "Shared", user_ids: %w[7 8] } }, xhr: true
         expect(@lead.user_ids.sort).to eq([he.id, she.id])
       end
 
@@ -746,11 +746,11 @@ describe LeadsController do
       expect(@account.access).to eq("Shared")
       expect(@account.permissions.map(&:user_id).sort).to eq([7, 8])
       expect(@account.permissions.map(&:asset_id)).to eq([@account.id, @account.id])
-      expect(@account.permissions.map(&:asset_type)).to eq(%w(Account Account))
+      expect(@account.permissions.map(&:asset_type)).to eq(%w[Account Account])
       expect(@opportunity.access).to eq("Shared")
       expect(@opportunity.permissions.map(&:user_id).sort).to eq([7, 8])
       expect(@opportunity.permissions.map(&:asset_id)).to eq([@opportunity.id, @opportunity.id])
-      expect(@opportunity.permissions.map(&:asset_type)).to eq(%w(Opportunity Opportunity))
+      expect(@opportunity.permissions.map(&:asset_type)).to eq(%w[Opportunity Opportunity])
     end
 
     it "should assign lead's campaign to the newly created opportunity" do

--- a/spec/controllers/entities/opportunities_controller_spec.rb
+++ b/spec/controllers/entities/opportunities_controller_spec.rb
@@ -49,7 +49,7 @@ describe OpportunitiesController do
       get :index
       # Note: can't compare opportunities directly because of BigDecimal objects.
       expect(assigns[:opportunities].size).to eq(2)
-      expect(assigns[:opportunities].map(&:stage).sort).to eq(%w(negotiation prospecting))
+      expect(assigns[:opportunities].map(&:stage).sort).to eq(%w[negotiation prospecting])
     end
 
     it "should perform lookup using query string" do

--- a/spec/factories/campaign_factories.rb
+++ b/spec/factories/campaign_factories.rb
@@ -9,7 +9,7 @@ FactoryGirl.define do
     name                { FFaker::Lorem.sentence[0, 64] }
     assigned_to nil
     access "Public"
-    status              { %w(planned started completed planned started completed on_hold called_off).sample }
+    status              { %w[planned started completed planned started completed on_hold called_off].sample }
     budget              { rand(500) }
     target_leads        { rand(200) }
     target_conversion   { rand(20) }

--- a/spec/factories/contact_factories.rb
+++ b/spec/factories/contact_factories.rb
@@ -14,7 +14,7 @@ FactoryGirl.define do
     access "Public"
     title               { FactoryGirl.generate(:title) }
     department          { FFaker::Name.name + " Dept." }
-    source              { %w(campaign cold_call conference online referral self web word_of_mouth other).sample }
+    source              { %w[campaign cold_call conference online referral self web word_of_mouth other].sample }
     email               { FFaker::Internet.email }
     alt_email           { FFaker::Internet.email }
     phone               { FFaker::PhoneNumber.phone_number }

--- a/spec/factories/field_factories.rb
+++ b/spec/factories/field_factories.rb
@@ -5,7 +5,7 @@
 #------------------------------------------------------------------------------
 FactoryGirl.define do
   sequence :klass_name do |_x|
-    %w(Contact Account Opportunity Lead Campaign).sample
+    %w[Contact Account Opportunity Lead Campaign].sample
   end
 
   sequence(:field_position) { |x| x }

--- a/spec/factories/lead_factories.rb
+++ b/spec/factories/lead_factories.rb
@@ -13,8 +13,8 @@ FactoryGirl.define do
     access "Public"
     company             { FFaker::Company.name }
     title               { FactoryGirl.generate(:title) }
-    source              { %w(campaign cold_call conference online referral self web word_of_mouth other).sample }
-    status              { %w(new contacted converted rejected).sample }
+    source              { %w[campaign cold_call conference online referral self web word_of_mouth other].sample }
+    status              { %w[new contacted converted rejected].sample }
     rating 1
     referred_by         { FFaker::Name.name }
     do_not_call false

--- a/spec/factories/opportunity_factories.rb
+++ b/spec/factories/opportunity_factories.rb
@@ -5,11 +5,11 @@
 #------------------------------------------------------------------------------
 FactoryGirl.define do
   sequence :opportunity_status do |_s|
-    %w(prospecting analysis presentation proposal negotiation final_review won lost).sample
+    %w[prospecting analysis presentation proposal negotiation final_review won lost].sample
   end
 
   sequence :opportunity_open_status do |_s|
-    %w(prospecting analysis presentation proposal negotiation final_review).sample
+    %w[prospecting analysis presentation proposal negotiation final_review].sample
   end
 
   factory :opportunity do
@@ -19,7 +19,7 @@ FactoryGirl.define do
     assigned_to nil
     name                { FFaker::Lorem.sentence[0, 64] }
     access "Public"
-    source              { %w(campaign cold_call conference online referral self web word_of_mouth other).sample }
+    source              { %w[campaign cold_call conference online referral self web word_of_mouth other].sample }
     stage               { FactoryGirl.generate(:opportunity_status) }
     probability         { rand(50) }
     amount              { rand(1000) }

--- a/spec/factories/shared_factories.rb
+++ b/spec/factories/shared_factories.rb
@@ -50,7 +50,7 @@ FactoryGirl.define do
     zipcode             { FFaker::AddressUS.zip_code }
     country             { FFaker::AddressUK.country }
     full_address        { FactoryGirl.generate(:address) }
-    address_type        { %w(Business Billing Shipping).sample }
+    address_type        { %w[Business Billing Shipping].sample }
     updated_at          { FactoryGirl.generate(:time) }
     created_at          { FactoryGirl.generate(:time) }
     deleted_at nil

--- a/spec/factories/task_factories.rb
+++ b/spec/factories/task_factories.rb
@@ -11,7 +11,7 @@ FactoryGirl.define do
     completed_by nil
     name                { FFaker::Lorem.sentence[0, 64] }
     priority nil
-    category            { %w(call email follow_up lunch meeting money presentation trip).sample }
+    category            { %w[call email follow_up lunch meeting money presentation trip].sample }
     bucket "due_asap"
     due_at              { FactoryGirl.generate(:time) }
     background_info     { FFaker::Lorem.paragraph[0, 255] }

--- a/spec/features/support/browser.rb
+++ b/spec/features/support/browser.rb
@@ -8,7 +8,7 @@
 #
 if ENV['BROWSER'] == 'chrome'
   Capybara.register_driver :selenium do |app|
-    capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: { args: %w(no-sandbox headless disable-gpu) })
+    capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: { args: ['no-sandbox', 'headless', 'disable-gpu'] })
     Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
   end
 else

--- a/spec/lib/permissions_spec.rb
+++ b/spec/lib/permissions_spec.rb
@@ -30,7 +30,7 @@ describe FatFreeCRM::Permissions do
 
     it "should assign permissions to the object" do
       expect(@entity.permissions.size).to eq(0)
-      @entity.user_ids = %w(1 2 3)
+      @entity.user_ids = %w[1 2 3]
       @entity.save!
       expect(@entity.permissions.where(user_id: [1, 2, 3]).size).to eq(3)
     end
@@ -44,7 +44,7 @@ describe FatFreeCRM::Permissions do
     it "should replace existing permissions" do
       @entity.permissions << FactoryGirl.create(:permission, user_id: 1, asset: @entity)
       @entity.permissions << FactoryGirl.create(:permission, user_id: 2, asset: @entity)
-      @entity.user_ids = %w(2 3)
+      @entity.user_ids = %w[2 3]
       @entity.save!
       expect(@entity.permissions.size).to eq(2)
       expect(@entity.permissions.where(user_id: [1]).size).to eq(0)
@@ -59,7 +59,7 @@ describe FatFreeCRM::Permissions do
     end
     it "should assign permissions to the object" do
       expect(@entity.permissions.size).to eq(0)
-      @entity.group_ids = %w(1 2 3)
+      @entity.group_ids = %w[1 2 3]
       @entity.save!
       expect(@entity.permissions.where(group_id: [1, 2, 3]).size).to eq(3)
     end

--- a/spec/lib/view_factory_spec.rb
+++ b/spec/lib/view_factory_spec.rb
@@ -13,7 +13,7 @@ describe FatFreeCRM::ViewFactory do
 
   describe "initialization" do
     before(:each) do
-      @view_params = { name: 'brief', title: 'Brief View', icon: 'fa-bars', controllers: ['contacts'], actions: %w(show index) }
+      @view_params = { name: 'brief', title: 'Brief View', icon: 'fa-bars', controllers: ['contacts'], actions: %w[show index] }
     end
 
     it "should initialize with required parameters" do
@@ -41,7 +41,7 @@ describe FatFreeCRM::ViewFactory do
 
   describe "views_for" do
     before(:each) do
-      @v1 = FatFreeCRM::ViewFactory.new name: 'brief', title: 'Brief View', controllers: ['contacts'], actions: %w(show index)
+      @v1 = FatFreeCRM::ViewFactory.new name: 'brief', title: 'Brief View', controllers: ['contacts'], actions: %w[show index]
       @v2 = FatFreeCRM::ViewFactory.new name: 'long', title: 'Long View', controllers: ['contacts'], actions: ['show']
       @v3 = FatFreeCRM::ViewFactory.new name: 'full', title: 'Full View', controllers: ['accounts'], actions: ['show']
     end

--- a/spec/models/fields/custom_field_spec.rb
+++ b/spec/models/fields/custom_field_spec.rb
@@ -45,7 +45,7 @@ describe CustomField do
     c = FactoryGirl.build(:custom_field, label: "Test Field", field_group: field_group)
 
     columns = []
-    %w(cf_test_field cf_test_field_2 cf_test_field_3 cf_test_field_4).each do |field|
+    %w[cf_test_field cf_test_field_2 cf_test_field_3 cf_test_field_4].each do |field|
       expect(c.send(:generate_column_name)).to eq(field)
       allow(Contact).to receive(:column_names).and_return(columns << field)
     end
@@ -63,8 +63,8 @@ describe CustomField do
   end
 
   it "should return a safe list of types for the 'as' select options" do
-    { "email"   => %w(check_boxes text string email url tel select radio_buttons),
-      "integer" => %w(integer float) }.each do |type, expected_arr|
+    { "email"   => %w[check_boxes text string email url tel select radio_buttons],
+      "integer" => %w[integer float] }.each do |type, expected_arr|
       c = FactoryGirl.build(:custom_field, as: type)
       opts = c.available_as
       expect(opts.map(&:first)).to match_array(expected_arr)

--- a/spec/models/observers/entity_observer_spec.rb
+++ b/spec/models/observers/entity_observer_spec.rb
@@ -11,7 +11,7 @@ describe EntityObserver do
     allow(PaperTrail).to receive(:whodunnit).and_return(assigner)
   end
 
-  [:account, :contact, :lead, :opportunity].each do |entity_type|
+  %i[account contact lead opportunity].each do |entity_type|
     describe "on creation of #{entity_type}" do
       let(:assignee) { FactoryGirl.create(:user) }
       let(:assigner) { FactoryGirl.create(:user) }

--- a/spec/models/polymorphic/version_spec.rb
+++ b/spec/models/polymorphic/version_spec.rb
@@ -34,7 +34,7 @@ describe Version, versioning: true do
     before do
       @lead = FactoryGirl.create(:lead)
 
-      %w(create destroy update view).each do |event|
+      %w[create destroy update view].each do |event|
         FactoryGirl.create(:version, event: event, item: @lead, whodunnit: PaperTrail.whodunnit)
         FactoryGirl.create(:version, event: event, item: @lead, whodunnit: "1")
       end
@@ -54,12 +54,12 @@ describe Version, versioning: true do
 
     it "should include only destroy events" do
       @versions = Version.for(current_user).include_events(:destroy)
-      expect(@versions.pluck(:event).uniq).to eq(%w(destroy))
+      expect(@versions.pluck(:event).uniq).to eq(['destroy'])
     end
 
     it "should include create and update events" do
       @versions = Version.for(current_user).include_events(:create, :update)
-      expect(@versions.pluck(:event).uniq.sort).to eq(%w(create update))
+      expect(@versions.pluck(:event).uniq.sort).to eq(%w[create update])
     end
 
     it "should select all versions for a given user" do
@@ -68,7 +68,7 @@ describe Version, versioning: true do
     end
   end
 
-  %w(account campaign contact lead opportunity task).each do |item|
+  %w[account campaign contact lead opportunity task].each do |item|
     describe "Create, update, and delete (#{item})" do
       before :each do
         @item = FactoryGirl.create(item.to_sym, user: current_user)
@@ -122,7 +122,7 @@ describe Version, versioning: true do
       @task.update(name: 'New Name')
 
       versions = Version.where(@conditions)
-      expect(versions.pluck(:event).sort).to eq(%w(create update)) # but not view
+      expect(versions.pluck(:event).sort).to eq(%w[create update]) # but not view
     end
   end
 
@@ -179,7 +179,7 @@ describe Version, versioning: true do
       @item.update(name: 'New Name')
 
       versions = Version.where(item_id: @item.id, item_type: @item.class.name)
-      expect(versions.pluck(:event).sort).to eq(%w(create update))
+      expect(versions.pluck(:event).sort).to eq(%w[create update])
 
       visible_versions = Version.visible_to(@user)
       expect(visible_versions).to eq([])
@@ -190,7 +190,7 @@ describe Version, versioning: true do
       @item.destroy
 
       versions = Version.where(item_id: @item.id, item_type: @item.class.name)
-      expect(versions.pluck(:event).sort).to eq(%w(create destroy))
+      expect(versions.pluck(:event).sort).to eq(%w[create destroy])
 
       visible_versions = Version.visible_to(@user)
       expect(visible_versions).to eq([])
@@ -205,7 +205,7 @@ describe Version, versioning: true do
       @item.update(name: 'New Name')
 
       versions = Version.where(item_id: @item.id, item_type: @item.class.name)
-      expect(versions.pluck(:event).sort).to eq(%w(create update))
+      expect(versions.pluck(:event).sort).to eq(%w[create update])
 
       visible_versions = Version.visible_to(@user)
       expect(visible_versions).to eq([])
@@ -220,7 +220,7 @@ describe Version, versioning: true do
       @item.destroy
 
       versions = Version.where(item_id: @item.id, item_type: @item.class.name)
-      expect(versions.pluck(:event).sort).to eq(%w(create destroy))
+      expect(versions.pluck(:event).sort).to eq(%w[create destroy])
 
       visible_versions = Version.visible_to(@user)
       expect(visible_versions).to eq([])
@@ -235,10 +235,10 @@ describe Version, versioning: true do
       @item.update(name: 'New Name')
 
       versions = Version.where(item_id: @item.id, item_type: @item.class.name)
-      expect(versions.pluck(:event).sort).to eq(%w(create update))
+      expect(versions.pluck(:event).sort).to eq(%w[create update])
 
       visible_versions = Version.visible_to(@user)
-      expect(visible_versions.map(&:event).sort).to eq(%w(create update))
+      expect(visible_versions.map(&:event).sort).to eq(%w[create update])
     end
   end
 end

--- a/spec/models/users/abilities/user_ability_spec.rb
+++ b/spec/models/users/abilities/user_ability_spec.rb
@@ -7,7 +7,7 @@ require 'spec_helper'
 require 'cancan/matchers'
 
 def all_actions
-  [:index, :show, :create, :update, :destroy, :manage]
+  %i[index show create update destroy manage]
 end
 
 describe "User abilities" do
@@ -32,7 +32,7 @@ describe "User abilities" do
   context "when another user, I" do
     let(:user)  { create :user }
     let(:can)    { [] }
-    let(:cannot) { [:show, :create, :update, :index, :destroy, :manage] }
+    let(:cannot) { %i[show create update index destroy manage] }
     it do
       can.each do |do_action|
         is_expected.to be_able_to(do_action, subject_user)
@@ -48,7 +48,7 @@ describe "User abilities" do
   context "when anonymous user, I" do
     let(:user)  { nil }
     let(:can)    { [] }
-    let(:cannot) { [:show, :create, :update, :index, :destroy, :manage] }
+    let(:cannot) { %i[show create update index destroy manage] }
     it do
       can.each do |do_action|
         is_expected.to be_able_to(do_action, subject_user)

--- a/spec/models/users/user_spec.rb
+++ b/spec/models/users/user_spec.rb
@@ -60,7 +60,7 @@ describe User do
         @user = FactoryGirl.build(:user)
       end
 
-      %w(account campaign lead contact opportunity).each do |asset|
+      %w[account campaign lead contact opportunity].each do |asset|
         it "should not destroy the user if she owns #{asset}" do
           FactoryGirl.create(asset, user: @user)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 # Load shared behavior modules to be included by Runner config.
 Dir["./spec/shared/**/*.rb"].sort.each { |f| require f }
 
-TASK_STATUSES = %w(pending assigned completed).freeze
+TASK_STATUSES = %w[pending assigned completed].freeze
 
 I18n.locale = 'en-US'
 

--- a/spec/views/application/auto_complete.haml_spec.rb
+++ b/spec/views/application/auto_complete.haml_spec.rb
@@ -12,7 +12,7 @@ describe "/application/_auto_complete" do
     login_and_assign
   end
 
-  [:account, :campaign, :contact, :lead, :opportunity].each do |model|
+  %i[account campaign contact lead opportunity].each do |model|
     it "should render autocomplete list if #{model} matches found" do
       @auto_complete = if model == :lead
                          FactoryGirl.build_stubbed(:lead, first_name: "Billy", last_name: "Bones", company: "Hello, World!")

--- a/spec/views/tasks/_edit.haml_spec.rb
+++ b/spec/views/tasks/_edit.haml_spec.rb
@@ -12,8 +12,8 @@ describe "/tasks/_edit" do
     login_and_assign
     assign(:task, FactoryGirl.build_stubbed(:task, asset: FactoryGirl.build_stubbed(:account), bucket: "due_asap"))
     assign(:users, [current_user])
-    assign(:bucket, %w(due_asap due_today))
-    assign(:category, %w(meeting money))
+    assign(:bucket, %w[due_asap due_today])
+    assign(:category, %w[meeting money])
   end
 
   it "should render [edit task] form" do

--- a/spec/views/tasks/create.js.haml_spec.rb
+++ b/spec/views/tasks/create.js.haml_spec.rb
@@ -12,7 +12,7 @@ describe "/tasks/create" do
     login_and_assign
   end
 
-  (TASK_STATUSES - %w(completed)).each do |status|
+  (TASK_STATUSES - ['completed']).each do |status|
     describe "create from #{status} tasks page" do
       before do
         assign(:view, status)
@@ -84,7 +84,7 @@ describe "/tasks/create" do
     expect(rendered).to have_text("Recent Items")
   end
 
-  (TASK_STATUSES - %w(assigned)).each do |status|
+  (TASK_STATUSES - ['assigned']).each do |status|
     describe "create from outside the Tasks tab" do
       before do
         @task = FactoryGirl.build_stubbed(:task, id: 42)

--- a/spec/views/tasks/edit.js.haml_spec.rb
+++ b/spec/views/tasks/edit.js.haml_spec.rb
@@ -15,7 +15,7 @@ describe "/tasks/edit" do
     assign(:category, Setting.unroll(:task_category))
   end
 
-  %w(pending assigned).each do |view|
+  %w[pending assigned].each do |view|
     it "cancel for #{view} view: should replace [Edit Task] form with the task partial" do
       params[:cancel] = "true"
       @task = stub_task(view)


### PR DESCRIPTION
Fix array angle brackets and usage of %w[x y z] vs ['x', 'y', 'x'] according to rubocop / ruby-style guide rules. Note there are some cases where ['x', 'y', 'x'] is preferred. This code was done using Rubocop's auto-correct