### PR TITLE
Use FixtureSet instead of Fixtures module

### DIFF
--- a/lib/tasks/ffcrm/demo.rake
+++ b/lib/tasks/ffcrm/demo.rake
@@ -10,7 +10,7 @@ namespace :ffcrm do
       # Load fixtures
       require 'active_record/fixtures'
       Dir.glob(FatFreeCRM.root.join('db', 'demo', '*.{yml,csv}')).each do |fixture_file|
-        ActiveRecord::Fixtures.create_fixtures(FatFreeCRM.root.join('db/demo'), File.basename(fixture_file, '.*'))
+        ActiveRecord::FixtureSet.create_fixtures(FatFreeCRM.root.join('db/demo'), File.basename(fixture_file, '.*'))
       end
 
       def create_version(options)


### PR DESCRIPTION
The module ActiveRecord::Fixtures was deprecated in Rails 4 and removed from 4.1. Closes #620