### PR TITLE
Devise Readiness (+ thread-safety): Refactor User.my scope

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -47,7 +47,7 @@ class Admin::UsersController < Admin::ApplicationController
   #----------------------------------------------------------------------------
   def create
     @user = User.new(user_params)
-    @user.check_if_needs_approval
+    @user.suspend_if_needs_approval
     @user.save_without_session_maintenance
 
     respond_with(@user)
@@ -74,7 +74,7 @@ class Admin::UsersController < Admin::ApplicationController
   # DELETE /admin/users/1.xml                                              AJAX
   #----------------------------------------------------------------------------
   def destroy
-    unless @user.destroyable? && @user.destroy
+    unless @user.destroyable?(current_user) && @user.destroy
       flash[:warning] = t(:msg_cant_delete_user, @user.full_name)
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,7 +38,7 @@ class ApplicationController < ActionController::Base
     @auto_complete = hook(:auto_complete, self, query: @query, user: current_user)
     if @auto_complete.empty?
       exclude_ids = auto_complete_ids_to_exclude(params[:related])
-      @auto_complete = klass.my.text_search(@query).ransack(id_not_in: exclude_ids).result.limit(10)
+      @auto_complete = klass.my(current_user).text_search(@query).ransack(id_not_in: exclude_ids).result.limit(10)
     else
       @auto_complete = @auto_complete.last
     end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -15,7 +15,7 @@ class CommentsController < ApplicationController
   def index
     @commentable = extract_commentable_name(params)
     if @commentable
-      @asset = @commentable.classify.constantize.my.find(params[:"#{@commentable}_id"])
+      @asset = @commentable.classify.constantize.my(current_user).find(params[:"#{@commentable}_id"])
       @comments = @asset.comments.order("created_at DESC")
     end
     respond_with(@comments) do |format|
@@ -38,7 +38,7 @@ class CommentsController < ApplicationController
 
     model = @comment.commentable_type
     id = @comment.commentable_id
-    unless model.constantize.my.find_by_id(id)
+    unless model.constantize.my(current_user).find_by_id(id)
       respond_to_related_not_found(model.downcase)
     end
   end
@@ -54,7 +54,7 @@ class CommentsController < ApplicationController
     # Make sure commentable object exists and is accessible to the current user.
     model = @comment.commentable_type
     id = @comment.commentable_id
-    if model.constantize.my.find_by_id(id)
+    if model.constantize.my(current_user).find_by_id(id)
       @comment.save
       respond_with(@comment)
     else

--- a/app/controllers/entities/accounts_controller.rb
+++ b/app/controllers/entities/accounts_controller.rb
@@ -46,7 +46,7 @@ class AccountsController < EntitiesController
   #----------------------------------------------------------------------------
   def edit
     if params[:previous].to_s =~ /(\d+)\z/
-      @previous = Account.my.find_by_id(Regexp.last_match[1]) || Regexp.last_match[1].to_i
+      @previous = Account.my(current_user).find_by_id(Regexp.last_match[1]) || Regexp.last_match[1].to_i
     end
 
     respond_with(@account)
@@ -155,11 +155,11 @@ class AccountsController < EntitiesController
   def get_data_for_sidebar
     @account_category_total = HashWithIndifferentAccess[
                               Setting.account_category.map do |key|
-                                [key, Account.my.where(category: key.to_s).count]
+                                [key, Account.my(current_user).where(category: key.to_s).count]
                               end
     ]
     categorized = @account_category_total.values.sum
-    @account_category_total[:all] = Account.my.count
+    @account_category_total[:all] = Account.my(current_user).count
     @account_category_total[:other] = @account_category_total[:all] - categorized
   end
 end

--- a/app/controllers/entities/campaigns_controller.rb
+++ b/app/controllers/entities/campaigns_controller.rb
@@ -71,7 +71,7 @@ class CampaignsController < EntitiesController
 
     if params[:related]
       model, id = params[:related].split('_')
-      if related = model.classify.constantize.my.find_by_id(id)
+      if related = model.classify.constantize.my(current_user).find_by_id(id)
         instance_variable_set("@#{model}", related)
       else
         respond_to_related_not_found(model) && return
@@ -85,7 +85,7 @@ class CampaignsController < EntitiesController
   #----------------------------------------------------------------------------
   def edit
     if params[:previous].to_s =~ /(\d+)\z/
-      @previous = Campaign.my.find_by_id(Regexp.last_match[1]) || Regexp.last_match[1].to_i
+      @previous = Campaign.my(current_user).find_by_id(Regexp.last_match[1]) || Regexp.last_match[1].to_i
     end
 
     respond_with(@campaign)
@@ -192,11 +192,11 @@ class CampaignsController < EntitiesController
   #----------------------------------------------------------------------------
   def get_data_for_sidebar
     @campaign_status_total = HashWithIndifferentAccess[
-                             all: Campaign.my.count,
+                             all: Campaign.my(current_user).count,
                              other: 0
     ]
     Setting.campaign_status.each do |key|
-      @campaign_status_total[key] = Campaign.my.where(status: key.to_s).count
+      @campaign_status_total[key] = Campaign.my(current_user).where(status: key.to_s).count
       @campaign_status_total[:other] -= @campaign_status_total[key]
     end
     @campaign_status_total[:other] += @campaign_status_total[:all]

--- a/app/controllers/entities/contacts_controller.rb
+++ b/app/controllers/entities/contacts_controller.rb
@@ -37,7 +37,7 @@ class ContactsController < EntitiesController
 
     if params[:related]
       model, id = params[:related].split('_')
-      if related = model.classify.constantize.my.find_by_id(id)
+      if related = model.classify.constantize.my(current_user).find_by_id(id)
         instance_variable_set("@#{model}", related)
       else
         respond_to_related_not_found(model) && return
@@ -52,7 +52,7 @@ class ContactsController < EntitiesController
   def edit
     @account = @contact.account || Account.new(user: current_user)
     if params[:previous].to_s =~ /(\d+)\z/
-      @previous = Contact.my.find_by_id(Regexp.last_match[1]) || Regexp.last_match[1].to_i
+      @previous = Contact.my(current_user).find_by_id(Regexp.last_match[1]) || Regexp.last_match[1].to_i
     end
 
     respond_with(@contact)
@@ -78,7 +78,7 @@ class ContactsController < EntitiesController
             @account = Account.find(params[:account][:id])
           end
         end
-        @opportunity = Opportunity.my.find(params[:opportunity]) unless params[:opportunity].blank?
+        @opportunity = Opportunity.my(current_user).find(params[:opportunity]) unless params[:opportunity].blank?
       end
     end
   end
@@ -157,7 +157,7 @@ class ContactsController < EntitiesController
 
   #----------------------------------------------------------------------------
   def get_accounts
-    @accounts = Account.my.order('name')
+    @accounts = Account.my(current_user).order('name')
   end
 
   def set_options

--- a/app/controllers/entities/leads_controller.rb
+++ b/app/controllers/entities/leads_controller.rb
@@ -37,7 +37,7 @@ class LeadsController < EntitiesController
 
     if params[:related]
       model, id = params[:related].split('_')
-      if related = model.classify.constantize.my.find_by_id(id)
+      if related = model.classify.constantize.my(current_user).find_by_id(id)
         instance_variable_set("@#{model}", related)
       else
         respond_to_related_not_found(model) && return
@@ -53,7 +53,7 @@ class LeadsController < EntitiesController
     get_campaigns
 
     if params[:previous].to_s =~ /(\d+)\z/
-      @previous = Lead.my.find_by_id(Regexp.last_match[1]) || Regexp.last_match[1].to_i
+      @previous = Lead.my(current_user).find_by_id(Regexp.last_match[1]) || Regexp.last_match[1].to_i
     end
 
     respond_with(@lead)
@@ -87,7 +87,7 @@ class LeadsController < EntitiesController
       if @lead.update_with_lead_counters(resource_params)
         update_sidebar
       else
-        @campaigns = Campaign.my.order('name')
+        @campaigns = Campaign.my(current_user).order('name')
       end
     end
   end
@@ -107,11 +107,11 @@ class LeadsController < EntitiesController
   #----------------------------------------------------------------------------
   def convert
     @account = Account.new(user: current_user, name: @lead.company, access: "Lead")
-    @accounts = Account.my.order('name')
+    @accounts = Account.my(current_user).order('name')
     @opportunity = Opportunity.new(user: current_user, access: "Lead", stage: "prospecting", campaign: @lead.campaign, source: @lead.source)
 
     if params[:previous].to_s =~ /(\d+)\z/
-      @previous = Lead.my.find_by_id(Regexp.last_match[1]) || Regexp.last_match[1].to_i
+      @previous = Lead.my(current_user).find_by_id(Regexp.last_match[1]) || Regexp.last_match[1].to_i
     end
 
     respond_with(@lead)
@@ -121,7 +121,7 @@ class LeadsController < EntitiesController
   #----------------------------------------------------------------------------
   def promote
     @account, @opportunity, @contact = @lead.promote(params.permit!)
-    @accounts = Account.my.order('name')
+    @accounts = Account.my(current_user).order('name')
     @stage = Setting.unroll(:opportunity_stage)
 
     respond_with(@lead) do |format|
@@ -206,7 +206,7 @@ class LeadsController < EntitiesController
 
   #----------------------------------------------------------------------------
   def get_campaigns
-    @campaigns = Campaign.my.order('name')
+    @campaigns = Campaign.my(current_user).order('name')
   end
 
   def set_options
@@ -241,11 +241,11 @@ class LeadsController < EntitiesController
       instance_variable_set("@#{related}", @lead.send(related)) if called_from_landing_page?(related.to_s.pluralize)
     else
       @lead_status_total = HashWithIndifferentAccess[
-                           all: Lead.my.count,
+                           all: Lead.my(current_user).count,
                            other: 0
       ]
       Setting.lead_status.each do |key|
-        @lead_status_total[key] = Lead.my.where(status: key.to_s).count
+        @lead_status_total[key] = Lead.my(current_user).where(status: key.to_s).count
         @lead_status_total[:other] -= @lead_status_total[key]
       end
       @lead_status_total[:other] += @lead_status_total[:all]

--- a/app/controllers/entities/opportunities_controller.rb
+++ b/app/controllers/entities/opportunities_controller.rb
@@ -35,11 +35,11 @@ class OpportunitiesController < EntitiesController
   def new
     @opportunity.attributes = { user: current_user, stage: Opportunity.default_stage, access: Setting.default_access, assigned_to: nil }
     @account     = Account.new(user: current_user, access: Setting.default_access)
-    @accounts    = Account.my.order('name')
+    @accounts    = Account.my(current_user).order('name')
 
     if params[:related]
       model, id = params[:related].split('_')
-      if related = model.classify.constantize.my.find_by_id(id)
+      if related = model.classify.constantize.my(current_user).find_by_id(id)
         instance_variable_set("@#{model}", related)
         @account = related.account if related.respond_to?(:account) && !related.account.nil?
         @campaign = related.campaign if related.respond_to?(:campaign)
@@ -55,10 +55,10 @@ class OpportunitiesController < EntitiesController
   #----------------------------------------------------------------------------
   def edit
     @account  = @opportunity.account || Account.new(user: current_user)
-    @accounts = Account.my.order('name')
+    @accounts = Account.my(current_user).order('name')
 
     if params[:previous].to_s =~ /(\d+)\z/
-      @previous = Opportunity.my.find_by_id(Regexp.last_match[1]) || Regexp.last_match[1].to_i
+      @previous = Opportunity.my(current_user).find_by_id(Regexp.last_match[1]) || Regexp.last_match[1].to_i
     end
 
     respond_with(@opportunity)
@@ -80,7 +80,7 @@ class OpportunitiesController < EntitiesController
           get_data_for_sidebar(:campaign)
         end
       else
-        @accounts = Account.my.order('name')
+        @accounts = Account.my(current_user).order('name')
         if params[:account][:id].blank?
           if request.referer =~ /\/accounts\/(\d+)\z/
             @account = Account.find(Regexp.last_match[1]) # related account
@@ -109,7 +109,7 @@ class OpportunitiesController < EntitiesController
           get_data_for_sidebar(:campaign)
         end
       else
-        @accounts = Account.my.order('name')
+        @accounts = Account.my(current_user).order('name')
         if @opportunity.account
           @account = Account.find(@opportunity.account.id)
         else
@@ -204,11 +204,11 @@ class OpportunitiesController < EntitiesController
       instance_variable_set("@#{related}", @opportunity.send(related)) if called_from_landing_page?(related.to_s.pluralize)
     else
       @opportunity_stage_total = HashWithIndifferentAccess[
-                                 all: Opportunity.my.count,
+                                 all: Opportunity.my(current_user).count,
                                  other: 0
       ]
       @stage.each do |_value, key|
-        @opportunity_stage_total[key] = Opportunity.my.where(stage: key.to_s).count
+        @opportunity_stage_total[key] = Opportunity.my(current_user).where(stage: key.to_s).count
         @opportunity_stage_total[:other] -= @opportunity_stage_total[key]
       end
       @opportunity_stage_total[:other] += @opportunity_stage_total[:all]

--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -111,7 +111,7 @@ class EntitiesController < ApplicationController
 
   #----------------------------------------------------------------------------
   def entities
-    instance_variable_get("@#{controller_name}") || klass.my
+    instance_variable_get("@#{controller_name}") || klass.my(current_user)
   end
 
   def set_options

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -40,7 +40,7 @@ class TasksController < ApplicationController
 
     if params[:related]
       model, id = params[:related].split(/_(\d+)/)
-      if related = model.classify.constantize.my.find_by_id(id)
+      if related = model.classify.constantize.my(current_user).find_by_id(id)
         instance_variable_set("@asset", related)
       else
         respond_to_related_not_found(model) && return

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -130,7 +130,7 @@ class UsersController < ApplicationController
   #----------------------------------------------------------------------------
   def opportunities_overview
     @users_with_opportunities = User.have_assigned_opportunities.order(:first_name)
-    @unassigned_opportunities = Opportunity.my.unassigned.pipeline.order(:stage).includes(:account, :user, :tags)
+    @unassigned_opportunities = Opportunity.my(current_user).unassigned.pipeline.order(:stage).includes(:account, :user, :tags)
   end
 
   protected

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -28,7 +28,7 @@ module AccountsHelper
   #----------------------------------------------------------------------------
   def account_select(options = {})
     options[:selected] = (@account&.id) || 0
-    accounts = ([@account] + Account.my.order(:name).limit(25)).compact.uniq
+    accounts = ([@account] + Account.my(current_user).order(:name).limit(25)).compact.uniq
     collection_select :account, :id, accounts, :id, :name, options,
                       "data-placeholder": t(:select_an_account),
                       "data-url": auto_complete_accounts_path(format: 'json'),

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -520,7 +520,7 @@ module ApplicationHelper
 
   #----------------------------------------------------------------------------
   # Ajaxification FTW!
-  # e.g. collection = Opportunity.my.scope
+  # e.g. collection = Opportunity.my(current_user).scope
   #         options = { renderer: {...} , params: {...}
   def paginate(options = {})
     collection = options.delete(:collection)

--- a/app/helpers/opportunities_helper.rb
+++ b/app/helpers/opportunities_helper.rb
@@ -39,7 +39,7 @@ module OpportunitiesHelper
   def opportunity_campaign_select(options = {})
     options[:selected] ||= @opportunity.campaign_id || 0
     selected_campaign = Campaign.find_by_id(options[:selected])
-    campaigns = ([selected_campaign] + Campaign.my.order(:name).limit(25)).compact.uniq
+    campaigns = ([selected_campaign] + Campaign.my(current_user).order(:name).limit(25)).compact.uniq
     collection_select :opportunity, :campaign_id, campaigns, :id, :name, options,
                       "data-placeholder": t(:select_a_campaign),
                       "data-url": auto_complete_campaigns_path(format: 'json'),

--- a/lib/fat_free_crm/permissions.rb
+++ b/lib/fat_free_crm/permissions.rb
@@ -22,9 +22,7 @@ module FatFreeCRM
           #
           has_many :permissions, as: :asset
 
-          scope :my, lambda {
-            accessible_by(User.current_ability)
-          }
+          scope :my, ->(current_user) { accessible_by(current_user.ability) }
 
           include FatFreeCRM::Permissions::InstanceMethods
           extend FatFreeCRM::Permissions::SingletonMethods

--- a/spec/models/users/user_spec.rb
+++ b/spec/models/users/user_spec.rb
@@ -65,7 +65,6 @@ describe User do
       %w[account campaign lead contact opportunity].each do |asset|
         it "should not destroy the user if she owns #{asset}" do
           FactoryGirl.create(asset, user: @user)
-
           expect(@user.destroyable?).to eq(false)
         end
 
@@ -75,17 +74,8 @@ describe User do
         end
       end
 
-      it "should not destroy the user if she owns a comment" do
-        login
-        account = build(:account, user: current_user)
-        FactoryGirl.create(:comment, user: @user, commentable: account)
-        expect(@user.destroyable?).to eq(false)
-      end
-
       it "should not destroy the current user" do
-        login
-
-        expect(current_user.destroyable?).to eq(false)
+        expect(@user.destroyable?(@user)).to eq(false)
       end
 
       it "should destroy the user" do
@@ -93,6 +83,7 @@ describe User do
       end
     end
   end
+
   describe '#destroy' do
     before do
       @user = FactoryGirl.create(:user)
@@ -114,12 +105,12 @@ describe User do
     end
   end
 
-  describe '#check_if_needs_approval' do
+  describe '#suspend_if_needs_approval' do
     it "should set suspended timestamp upon creation if signups need approval and the user is not an admin" do
       allow(Setting).to receive(:user_signup).and_return(:needs_approval)
       @user = FactoryGirl.build(:user, suspended_at: nil)
 
-      @user.check_if_needs_approval
+      @user.suspend_if_needs_approval
 
       expect(@user).to be_suspended
     end
@@ -128,7 +119,7 @@ describe User do
       allow(Setting).to receive(:user_signup).and_return(:needs_approval)
       @user = FactoryGirl.build(:user, admin: true, suspended_at: nil)
 
-      @user.check_if_needs_approval
+      @user.suspend_if_needs_approval
 
       expect(@user).not_to be_suspended
     end

--- a/spec/models/users/user_spec.rb
+++ b/spec/models/users/user_spec.rb
@@ -60,17 +60,18 @@ describe User do
     describe "Destroying users with and without related assets" do
       before do
         @user = FactoryGirl.build(:user)
+        @current_user = FactoryGirl.build(:user)
       end
 
       %w[account campaign lead contact opportunity].each do |asset|
         it "should not destroy the user if she owns #{asset}" do
           FactoryGirl.create(asset, user: @user)
-          expect(@user.destroyable?).to eq(false)
+          expect(@user.destroyable?(@current_user)).to eq(false)
         end
 
         it "should not destroy the user if she has #{asset} assigned" do
           FactoryGirl.create(asset, assignee: @user)
-          expect(@user.destroyable?).to eq(false)
+          expect(@user.destroyable?(@current_user)).to eq(false)
         end
       end
 
@@ -79,7 +80,7 @@ describe User do
       end
 
       it "should destroy the user" do
-        expect(@user.destroyable?).to eq(true)
+        expect(@user.destroyable?(@current_user)).to eq(true)
       end
     end
   end


### PR DESCRIPTION
- User.current_user (thread unsafe) should not be used within model instance scope. Instead, we should only do a thread unsafe variable in the controllers, as the controller action is run on a single thread. IT seems that Authlogic allows you to access the `current_user` variable inside models via a monkey patch, but Devise does not.
- Refactor User.current_ability to be an instance method User#abiltiy
- .my scope is now .my(current_user)
- Rename User#check_if_needs_approval to User#suspend_if_needs_approval
  