### PR TITLE
Devise readiness: Simplify login spec helper

### DIFF
--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -9,7 +9,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Admin::UsersController do
   before(:each) do
-    require_user(admin: true)
+    login_admin
     set_current_tab(:users)
   end
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -11,7 +11,7 @@ describe CommentsController do
   COMMENTABLE = %i[account campaign contact lead opportunity].freeze
 
   before(:each) do
-    require_user
+    login
   end
 
   # GET /comments

--- a/spec/controllers/emails_controller_spec.rb
+++ b/spec/controllers/emails_controller_spec.rb
@@ -11,7 +11,7 @@ describe EmailsController, "handling GET /emails" do
   MEDIATOR = %i[account campaign contact lead opportunity].freeze
 
   before(:each) do
-    require_user
+    login
   end
 
   # DELETE /emails/1

--- a/spec/controllers/entities/accounts_controller_spec.rb
+++ b/spec/controllers/entities/accounts_controller_spec.rb
@@ -13,7 +13,7 @@ describe AccountsController do
   end
 
   before do
-    require_user
+    login
     set_current_tab(:accounts)
   end
 

--- a/spec/controllers/entities/campaigns_controller_spec.rb
+++ b/spec/controllers/entities/campaigns_controller_spec.rb
@@ -13,7 +13,7 @@ describe CampaignsController do
   end
 
   before(:each) do
-    require_user
+    login
     set_current_tab(:campaigns)
   end
 

--- a/spec/controllers/entities/contacts_controller_spec.rb
+++ b/spec/controllers/entities/contacts_controller_spec.rb
@@ -9,7 +9,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe ContactsController do
   before(:each) do
-    require_user
+    login
     set_current_tab(:contacts)
   end
 

--- a/spec/controllers/entities/leads_controller_spec.rb
+++ b/spec/controllers/entities/leads_controller_spec.rb
@@ -9,7 +9,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe LeadsController do
   before(:each) do
-    require_user
+    login
     set_current_tab(:leads)
   end
 

--- a/spec/controllers/entities/opportunities_controller_spec.rb
+++ b/spec/controllers/entities/opportunities_controller_spec.rb
@@ -13,7 +13,7 @@ describe OpportunitiesController do
   end
 
   before do
-    require_user
+    login
     set_current_tab(:opportunities)
   end
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -12,7 +12,7 @@ describe HomeController do
   #----------------------------------------------------------------------------
   describe "responding to GET /" do
     before(:each) do
-      require_user
+      login
     end
 
     it "should get a list of activities" do
@@ -83,7 +83,7 @@ describe HomeController do
   #----------------------------------------------------------------------------
   describe "responding to GET options" do
     before(:each) do
-      require_user
+      login
     end
 
     it "should assign instance variables for user preferences" do
@@ -111,7 +111,7 @@ describe HomeController do
   #----------------------------------------------------------------------------
   describe "responding to GET redraw" do
     before(:each) do
-      require_user
+      login
     end
 
     it "should save user selected options" do
@@ -187,7 +187,7 @@ describe HomeController do
 
   describe "timeline" do
     before(:each) do
-      require_user
+      login
     end
 
     it "should collapse all comments and emails on a specific contact" do

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -47,7 +47,7 @@ describe TasksController do
   end
 
   before(:each) do
-    require_user
+    login
     set_current_tab(:tasks)
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -152,7 +152,7 @@ describe UsersController do
       end
 
       it "exposes a newly created user as @user and redirect to profile page" do
-        require_user(admin: true)
+        login_admin
         post :create, params: { user: { username: @username, email: @email, password: @password, password_confirmation: @password } }
         expect(assigns[:user]).to eq(@user)
         expect(flash[:notice]).to match(/welcome/)
@@ -171,7 +171,7 @@ describe UsersController do
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved user as @user and renders [new] template" do
-        require_user(admin: true)
+        login_admin
         @user = FactoryGirl.build(:user, username: "", email: "")
         allow(User).to receive(:new).and_return(@user)
 
@@ -312,7 +312,7 @@ describe UsersController do
   #----------------------------------------------------------------------------
   describe "responding to PUT change_password" do
     before(:each) do
-      require_user
+      login
       allow(User).to receive(:find).and_return(current_user)
       allow(@current_user_session).to receive(:unauthorized_record=).and_return(current_user)
       allow(@current_user_session).to receive(:save).and_return(current_user)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -13,7 +13,7 @@ describe UsersController do
   #----------------------------------------------------------------------------
   describe "responding to GET show" do
     before(:each) do
-      require_user
+      login
     end
 
     it "should render [show] template" do
@@ -30,7 +30,7 @@ describe UsersController do
 
     it "should show user if admin user" do
       @user = create(:user)
-      require_user(admin: true)
+      login_admin
       get :show, params: { id: @user.id }
       expect(assigns[:user]).to eq(@user)
       expect(response).to render_template("users/show")
@@ -49,14 +49,14 @@ describe UsersController do
 
       it "should render the requested user as JSON" do
         expect(User).to receive(:find).and_return(current_user)
-        expect(current_user).to receive(:to_json).and_return("generated JSON")
+        expect_any_instance_of(User).to receive(:to_json).and_return("generated JSON")
 
         get :show, params: { id: current_user.id }
         expect(response.body).to eq("generated JSON")
       end
 
       it "should render current user as JSON if no specific user was requested" do
-        expect(current_user).to receive(:to_json).and_return("generated JSON")
+        expect_any_instance_of(User).to receive(:to_json).and_return("generated JSON")
 
         get :show
         expect(response.body).to eq("generated JSON")
@@ -70,14 +70,14 @@ describe UsersController do
 
       it "should render the requested user as XML" do
         expect(User).to receive(:find).and_return(current_user)
-        expect(current_user).to receive(:to_xml).and_return("generated XML")
+        expect_any_instance_of(User).to receive(:to_xml).and_return("generated XML")
 
         get :show, params: { id: current_user.id }
         expect(response.body).to eq("generated XML")
       end
 
       it "should render current user as XML if no specific user was requested" do
-        expect(current_user).to receive(:to_xml).and_return("generated XML")
+        expect_any_instance_of(User).to receive(:to_xml).and_return("generated XML")
 
         get :show
         expect(response.body).to eq("generated XML")
@@ -115,7 +115,7 @@ describe UsersController do
   #----------------------------------------------------------------------------
   describe "responding to GET edit" do
     it "should expose current user as @user and render [edit] template" do
-      require_user
+      login
       @user = current_user
       get :edit, params: { id: @user.id }, xhr: true
       expect(assigns[:user]).to eq(current_user)
@@ -124,13 +124,13 @@ describe UsersController do
 
     it "should not allow current user to edit another user" do
       @user = create(:user)
-      require_user
+      login
       get :edit, params: { id: @user.id }, xhr: true
       expect(response.body).to eql("window.location.reload();")
     end
 
     it "should allow admin to edit another user" do
-      require_user(admin: true)
+      login_admin
       @user = create(:user)
       get :edit, params: { id: @user.id }, xhr: true
       expect(assigns[:user]).to eq(@user)
@@ -187,7 +187,7 @@ describe UsersController do
   #----------------------------------------------------------------------------
   describe "responding to PUT update" do
     before(:each) do
-      require_user
+      login
       @user = current_user
     end
 
@@ -217,7 +217,7 @@ describe UsersController do
   #----------------------------------------------------------------------------
   describe "responding to DELETE destroy" do
     before(:each) do
-      require_user
+      login
     end
 
     it "should destroy the requested user" do
@@ -232,7 +232,7 @@ describe UsersController do
   #----------------------------------------------------------------------------
   describe "responding to GET avatar" do
     before(:each) do
-      require_user
+      login
       @user = current_user
     end
 
@@ -248,7 +248,7 @@ describe UsersController do
   #----------------------------------------------------------------------------
   describe "responding to PUT update_avatar" do
     before(:each) do
-      require_user
+      login
       @user = current_user
     end
 
@@ -296,7 +296,7 @@ describe UsersController do
   #----------------------------------------------------------------------------
   describe "responding to GET avatar" do
     before(:each) do
-      require_user
+      login
       @user = current_user
     end
 
@@ -367,7 +367,7 @@ describe UsersController do
   #----------------------------------------------------------------------------
   describe "responding to GET opportunities_overview" do
     before(:each) do
-      require_user
+      login
       @user = @current_user
       @user.update_attributes(first_name: "Apple", last_name: "Boy")
     end

--- a/spec/models/entities/account_spec.rb
+++ b/spec/models/entities/account_spec.rb
@@ -30,7 +30,7 @@
 require 'spec_helper'
 
 describe Account do
-  before { login }
+  let(:current_user) { FactoryGirl.create(:user) }
 
   it "should create a new instance given valid attributes" do
     Account.create!(name: "Test Account", user: FactoryGirl.create(:user))

--- a/spec/models/entities/campaign_spec.rb
+++ b/spec/models/entities/campaign_spec.rb
@@ -34,7 +34,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Campaign do
-  before { login }
+  let(:current_user) { FactoryGirl.create(:user) }
 
   it "should create a new instance given valid attributes" do
     Campaign.create!(name: "Campaign", user: FactoryGirl.create(:user))

--- a/spec/models/entities/contact_spec.rb
+++ b/spec/models/entities/contact_spec.rb
@@ -41,7 +41,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Contact do
-  before { login }
+  let(:current_user) { FactoryGirl.create(:user) }
 
   it "should create a new instance given valid attributes" do
     Contact.create!(first_name: "Billy", last_name: "Bones")

--- a/spec/models/entities/lead_spec.rb
+++ b/spec/models/entities/lead_spec.rb
@@ -41,7 +41,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Lead do
-  before { login }
+  let(:current_user) { FactoryGirl.create(:user) }
 
   it "should create a new instance given valid attributes" do
     Lead.create!(first_name: "Billy", last_name: "Bones")

--- a/spec/models/entities/opportunity_spec.rb
+++ b/spec/models/entities/opportunity_spec.rb
@@ -30,15 +30,13 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Opportunity do
-  let(:current_user) { FactoryGirl.create(:user) }
-
   it "should create a new instance given valid attributes" do
     Opportunity.create!(name: "Opportunity", stage: 'analysis')
   end
 
   it "should be possible to create opportunity with the same name" do
-    FactoryGirl.create(:opportunity, name: "Hello", user: current_user)
-    expect { FactoryGirl.create(:opportunity, name: "Hello", user: current_user) }.to_not raise_error
+    FactoryGirl.create(:opportunity, name: "Hello")
+    expect { FactoryGirl.create(:opportunity, name: "Hello") }.to_not raise_error
   end
 
   it "have a default stage" do
@@ -153,7 +151,7 @@ describe Opportunity do
     end
 
     it "should return nil when attaching existing asset" do
-      @task = FactoryGirl.create(:task, asset: @opportunity, user: current_user)
+      @task = FactoryGirl.create(:task, asset: @opportunity)
       @contact = FactoryGirl.create(:contact)
       @opportunity.contacts << @contact
 
@@ -162,7 +160,7 @@ describe Opportunity do
     end
 
     it "should return non-empty list of attachments when attaching new asset" do
-      @task = FactoryGirl.create(:task, user: current_user)
+      @task = FactoryGirl.create(:task)
       @contact = FactoryGirl.create(:contact)
 
       expect(@opportunity.attach!(@task)).to eq([@task])
@@ -176,7 +174,7 @@ describe Opportunity do
     end
 
     it "should discard a task" do
-      @task = FactoryGirl.create(:task, asset: @opportunity, user: current_user)
+      @task = FactoryGirl.create(:task, asset: @opportunity)
       expect(@opportunity.tasks.count).to eq(1)
 
       @opportunity.discard!(@task)

--- a/spec/models/entities/opportunity_spec.rb
+++ b/spec/models/entities/opportunity_spec.rb
@@ -30,7 +30,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Opportunity do
-  before { login }
+  let(:current_user) { FactoryGirl.create(:user) }
 
   it "should create a new instance given valid attributes" do
     Opportunity.create!(name: "Opportunity", stage: 'analysis')

--- a/spec/models/polymorphic/address_spec.rb
+++ b/spec/models/polymorphic/address_spec.rb
@@ -28,10 +28,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Address do
-  before(:each) do
-    login
-  end
-
   it "should create a new instance given valid attributes" do
     Address.create!(street1: "street1", street2: "street2", city: "city", state: "state", zipcode: "zipcode", country: "country", full_address: "fa", address_type: "Lead", addressable: FactoryGirl.create(:lead))
   end

--- a/spec/models/polymorphic/comment_spec.rb
+++ b/spec/models/polymorphic/comment_spec.rb
@@ -24,10 +24,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Comment do
-  before(:each) do
-    login
-  end
-
   it "should create a new instance given valid attributes" do
     Comment.create!(comment: "Hello", user: FactoryGirl.create(:user), commentable: FactoryGirl.create(:lead))
   end

--- a/spec/models/polymorphic/task_spec.rb
+++ b/spec/models/polymorphic/task_spec.rb
@@ -32,7 +32,7 @@
 require 'spec_helper'
 
 describe Task do
-  before { login }
+  let(:current_user) { FactoryGirl.create(:user) }
 
   describe "Task/Create" do
     it "should create a new task instance given valid attributes" do

--- a/spec/models/polymorphic/version_spec.rb
+++ b/spec/models/polymorphic/version_spec.rb
@@ -23,10 +23,8 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Version, versioning: true do
-  before do
-    login
-    PaperTrail.whodunnit = current_user.id.to_s
-  end
+  let(:current_user) { FactoryGirl.create(:user) }
+  before { PaperTrail.whodunnit = current_user.id.to_s }
 
   it "should create a new instance given valid attributes" do
     FactoryGirl.create(:version, whodunnit: PaperTrail.whodunnit, item: FactoryGirl.create(:lead))

--- a/spec/models/users/user_spec.rb
+++ b/spec/models/users/user_spec.rb
@@ -75,18 +75,7 @@ describe User do
         end
       end
 
-      it "should not destroy the user if she owns a comment" do
-        login
-        account = build(:account, user: current_user)
-        FactoryGirl.create(:comment, user: @user, commentable: account)
-        expect(@user.destroyable?).to eq(false)
-      end
-
-      it "should not destroy the current user" do
-        login
-
-        expect(current_user.destroyable?).to eq(false)
-      end
+      # USE THE OTHER VERSION (from PR #671) WHEN RESOLVING CONFLICTS HERE
 
       it "should destroy the user" do
         expect(@user.destroyable?).to eq(true)

--- a/spec/support/auth_macros.rb
+++ b/spec/support/auth_macros.rb
@@ -22,21 +22,12 @@ def login(user_stubs = {}, session_stubs = {})
   @current_user_session = double(Authentication, { record: current_user }.merge(session_stubs))
   allow(Authentication).to receive(:find).and_return(@current_user_session)
   # set_timezone
+  assigns[:current_user] = current_user
 end
-alias require_user login
 
 #----------------------------------------------------------------------------
-def login_and_assign(user_stubs = {}, session_stubs = {})
-  User.current_user = @current_user = FactoryGirl.build_stubbed(:user, user_stubs)
-  @current_user_session = double(Authentication, { record: current_user }.merge(session_stubs))
-  allow(Authentication).to receive(:find).and_return(@current_user_session)
-  # set_timezone
-  assigns[:current_user] = current_user
-end
-
-def login_and_assign!(_user_stubs = {}, _session_stubs = {})
-  login
-  assigns[:current_user] = current_user
+def login_admin
+  login(admin: true)
 end
 
 #----------------------------------------------------------------------------

--- a/spec/views/accounts/_edit.haml_spec.rb
+++ b/spec/views/accounts/_edit.haml_spec.rb
@@ -11,9 +11,8 @@ describe "/accounts/_edit" do
   include AccountsHelper
 
   before do
-    login_and_assign
-    assign(:account, @account = FactoryGirl.build_stubbed(:account))
-    assign(:users, [current_user])
+    login
+    assign(:account, @account = FactoryGirl.create(:account))
   end
 
   it "should render [edit account] form" do

--- a/spec/views/accounts/_new.haml_spec.rb
+++ b/spec/views/accounts/_new.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/accounts/_new" do
   include AccountsHelper
 
   before do
-    login_and_assign
+    login
     assign(:account, Account.new)
     assign(:users, [current_user])
   end

--- a/spec/views/accounts/create.js.haml_spec.rb
+++ b/spec/views/accounts/create.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/accounts/create" do
   include AccountsHelper
 
   before do
-    login_and_assign
+    login
   end
 
   # Note: [Create Account] is only called from Accounts index. Unlike other

--- a/spec/views/accounts/destroy.js.haml_spec.rb
+++ b/spec/views/accounts/destroy.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/accounts/destroy" do
   include AccountsHelper
 
   before do
-    login_and_assign
+    login
     assign(:account, @account = FactoryGirl.build_stubbed(:account))
     assign(:accounts, [@account].paginate)
     assign(:account_category_total, Hash.new(1))

--- a/spec/views/accounts/edit.js.haml_spec.rb
+++ b/spec/views/accounts/edit.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/accounts/edit" do
   include AccountsHelper
 
   before do
-    login_and_assign
+    login
     assign(:account, @account = FactoryGirl.build_stubbed(:account, user: current_user))
     assign(:users, [current_user])
   end

--- a/spec/views/accounts/index.haml_spec.rb
+++ b/spec/views/accounts/index.haml_spec.rb
@@ -15,7 +15,7 @@ describe "/accounts/index" do
     assign :per_page, Account.per_page
     assign :sort_by,  Account.sort_by
     assign :ransack_search, Account.ransack
-    login_and_assign
+    login
   end
 
   it "should render account name" do

--- a/spec/views/accounts/index.js.haml_spec.rb
+++ b/spec/views/accounts/index.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/accounts/index" do
   include AccountsHelper
 
   before do
-    login_and_assign
+    login
   end
 
   it "should render [account] template with @accounts collection if there are accounts" do

--- a/spec/views/accounts/new.js.haml_spec.rb
+++ b/spec/views/accounts/new.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/accounts/new" do
   include AccountsHelper
 
   before do
-    login_and_assign
+    login
     assign(:account, Account.new(user: current_user))
     assign(:users, [current_user])
   end

--- a/spec/views/accounts/show.haml_spec.rb
+++ b/spec/views/accounts/show.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/accounts/show" do
   include AccountsHelper
 
   before do
-    login_and_assign
+    login
     @account = FactoryGirl.create(:account, id: 42,
                                             contacts: [FactoryGirl.create(:contact)],
                                             opportunities: [FactoryGirl.create(:opportunity)])

--- a/spec/views/accounts/update.js.haml_spec.rb
+++ b/spec/views/accounts/update.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/accounts/update" do
   include AccountsHelper
 
   before do
-    login_and_assign
+    login
 
     assign(:account, @account = FactoryGirl.build_stubbed(:account, user: current_user))
     assign(:users, [current_user])

--- a/spec/views/admin/field_groups/create.js.haml_spec.rb
+++ b/spec/views/admin/field_groups/create.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "admin/field_groups/create" do
   before do
-    login_and_assign(admin: true)
+    login_admin
     assign(:field_group, field_group)
   end
 

--- a/spec/views/admin/field_groups/destroy.js.haml_spec.rb
+++ b/spec/views/admin/field_groups/destroy.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "admin/field_groups/destroy" do
   before do
-    login_and_assign(admin: true)
+    login_admin
     assign(:field_group, field_group)
   end
 

--- a/spec/views/admin/field_groups/edit.js.haml_spec.rb
+++ b/spec/views/admin/field_groups/edit.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "admin/field_groups/edit" do
   before do
-    login_and_assign(admin: true)
+    login_admin
     assign(:field_group, field_group)
   end
 

--- a/spec/views/admin/field_groups/new.js.haml_spec.rb
+++ b/spec/views/admin/field_groups/new.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "admin/field_groups/new" do
   before do
-    login_and_assign(admin: true)
+    login_admin
     assign(:field_group, field_group)
   end
 

--- a/spec/views/admin/field_groups/update.js.haml_spec.rb
+++ b/spec/views/admin/field_groups/update.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "admin/field_groups/update" do
   before do
-    login_and_assign(admin: true)
+    login_admin
     assign(:field_group, field_group)
   end
 

--- a/spec/views/admin/users/_create.haml_spec.rb
+++ b/spec/views/admin/users/_create.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "admin/users/_new" do
   before do
-    login_and_assign(admin: true)
+    login_admin
     assign(:user, User.new)
     assign(:users, [current_user])
   end

--- a/spec/views/admin/users/create.js.haml_spec.rb
+++ b/spec/views/admin/users/create.js.haml_spec.rb
@@ -9,7 +9,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper')
 
 describe "admin/users/create" do
   before do
-    login_and_assign(admin: true)
+    login_admin
   end
 
   describe "create success" do

--- a/spec/views/admin/users/destroy.js.haml_spec.rb
+++ b/spec/views/admin/users/destroy.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "admin/users/destroy" do
   before do
-    login_and_assign(admin: true)
+    login_admin
   end
 
   describe "user got deleted" do

--- a/spec/views/admin/users/edit.js.haml_spec.rb
+++ b/spec/views/admin/users/edit.js.haml_spec.rb
@@ -9,7 +9,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper')
 
 describe "admin/users/edit" do
   before do
-    login_and_assign(admin: true)
+    login_admin
     assign(:user, @user = FactoryGirl.build_stubbed(:user))
   end
 

--- a/spec/views/admin/users/index.haml_spec.rb
+++ b/spec/views/admin/users/index.haml_spec.rb
@@ -9,7 +9,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper')
 
 describe "/admin/users/index" do
   before do
-    login_and_assign(admin: true)
+    login_admin
   end
 
   it "renders a list of users" do

--- a/spec/views/admin/users/index.js.haml_spec.rb
+++ b/spec/views/admin/users/index.js.haml_spec.rb
@@ -9,7 +9,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper')
 
 describe "admin/users/index" do
   before do
-    login_and_assign
+    login
   end
 
   it "renders [admin/user] template with @users collection" do

--- a/spec/views/admin/users/new.js.haml_spec.rb
+++ b/spec/views/admin/users/new.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "admin/users/new" do
   before do
-    login_and_assign(admin: true)
+    login_admin
     assign(:user, User.new)
   end
 

--- a/spec/views/admin/users/reactivate.js.haml_spec.rb
+++ b/spec/views/admin/users/reactivate.js.haml_spec.rb
@@ -9,7 +9,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper')
 
 describe "admin/users/reactivate" do
   before do
-    login_and_assign(admin: true)
+    login_admin
     assign(:user, @user = FactoryGirl.build_stubbed(:user, suspended_at: Time.now.yesterday))
   end
 

--- a/spec/views/admin/users/suspend.js.haml_spec.rb
+++ b/spec/views/admin/users/suspend.js.haml_spec.rb
@@ -9,7 +9,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper')
 
 describe "admin/users/suspend" do
   before do
-    login_and_assign(admin: true)
+    login_admin
     assign(:user, @user = FactoryGirl.build_stubbed(:user, suspended_at: nil))
   end
 

--- a/spec/views/admin/users/update.js.haml_spec.rb
+++ b/spec/views/admin/users/update.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "admin/users/update" do
   before do
-    login_and_assign(admin: true)
+    login_admin
     assign(:user, @user = FactoryGirl.build_stubbed(:user))
   end
 

--- a/spec/views/application/auto_complete.haml_spec.rb
+++ b/spec/views/application/auto_complete.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/application/_auto_complete" do
   include AccountsHelper
 
   before do
-    login_and_assign
+    login
   end
 
   %i[account campaign contact lead opportunity].each do |model|

--- a/spec/views/campaigns/_edit.haml_spec.rb
+++ b/spec/views/campaigns/_edit.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/campaigns/_edit" do
   include CampaignsHelper
 
   before do
-    login_and_assign
+    login
     assign(:campaign, @campaign = FactoryGirl.build_stubbed(:campaign))
     assign(:users, [current_user])
   end

--- a/spec/views/campaigns/_new.haml_spec.rb
+++ b/spec/views/campaigns/_new.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/campaigns/_new" do
   include CampaignsHelper
 
   before do
-    login_and_assign
+    login
     assign(:campaign, Campaign.new)
     assign(:users, [current_user])
   end

--- a/spec/views/campaigns/create.js.haml_spec.rb
+++ b/spec/views/campaigns/create.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "/campaigns/create" do
   before do
-    login_and_assign
+    login
   end
 
   describe "create success" do

--- a/spec/views/campaigns/destroy.js.haml_spec.rb
+++ b/spec/views/campaigns/destroy.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "/campaigns/destroy" do
   before do
-    login_and_assign
+    login
     assign(:campaign, @campaign = FactoryGirl.build_stubbed(:campaign, user: current_user))
     assign(:campaigns, [@campaign].paginate)
     assign(:campaign_status_total, Hash.new(1))

--- a/spec/views/campaigns/edit.js.haml_spec.rb
+++ b/spec/views/campaigns/edit.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/campaigns/edit" do
   include CampaignsHelper
 
   before do
-    login_and_assign
+    login
     assign(:campaign, @campaign = FactoryGirl.build_stubbed(:campaign, user: current_user))
     assign(:users, [current_user])
   end

--- a/spec/views/campaigns/index.haml_spec.rb
+++ b/spec/views/campaigns/index.haml_spec.rb
@@ -15,7 +15,7 @@ describe "/campaigns/index" do
     assign :per_page, Campaign.per_page
     assign :sort_by,  Campaign.sort_by
     assign :ransack_search, Campaign.ransack
-    login_and_assign
+    login
   end
 
   it "should render list of accounts if list of campaigns is not empty" do

--- a/spec/views/campaigns/index.js.haml_spec.rb
+++ b/spec/views/campaigns/index.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/campaigns/index" do
   include CampaignsHelper
 
   before do
-    login_and_assign
+    login
   end
 
   it "should render [campaign] template with @campaigns collection if there are campaigns" do

--- a/spec/views/campaigns/new.js.haml_spec.rb
+++ b/spec/views/campaigns/new.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/campaigns/new" do
   include CampaignsHelper
 
   before do
-    login_and_assign
+    login
     assign(:campaign, Campaign.new(user: current_user))
     assign(:users, [current_user])
   end

--- a/spec/views/campaigns/show.haml_spec.rb
+++ b/spec/views/campaigns/show.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/campaigns/show" do
   include CampaignsHelper
 
   before do
-    login_and_assign
+    login
     @campaign = FactoryGirl.build_stubbed(:campaign, id: 42,
                                                      leads: [FactoryGirl.build_stubbed(:lead)],
                                                      opportunities: [FactoryGirl.build_stubbed(:opportunity)])

--- a/spec/views/campaigns/update.js.haml_spec.rb
+++ b/spec/views/campaigns/update.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "/campaigns/update" do
   before do
-    login_and_assign
+    login
     assign(:campaign, @campaign = FactoryGirl.build_stubbed(:campaign, user: current_user))
     assign(:users, [current_user])
     assign(:status, Setting.campaign_status)

--- a/spec/views/comments/edit.js.haml_spec.rb
+++ b/spec/views/comments/edit.js.haml_spec.rb
@@ -11,6 +11,7 @@ describe "/comments/edit" do
   include CommentsHelper
 
   before do
+    login
     assign(:comment, stub_model(Comment,
                                 id: 321,
                                 new_record?: false,

--- a/spec/views/contacts/_edit.haml_spec.rb
+++ b/spec/views/contacts/_edit.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/contacts/_edit" do
   include ContactsHelper
 
   before do
-    login_and_assign
+    login
     assign(:account, @account = FactoryGirl.create(:account))
     assign(:accounts, [@account])
   end

--- a/spec/views/contacts/_new.haml_spec.rb
+++ b/spec/views/contacts/_new.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/contacts/_new" do
   include ContactsHelper
 
   before do
-    login_and_assign
+    login
     @account = FactoryGirl.build_stubbed(:account)
     assign(:contact, Contact.new)
     assign(:users, [current_user])

--- a/spec/views/contacts/create.js.haml_spec.rb
+++ b/spec/views/contacts/create.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/contacts/create" do
   include ContactsHelper
 
   before do
-    login_and_assign
+    login
   end
 
   describe "create success" do

--- a/spec/views/contacts/destroy.js.haml_spec.rb
+++ b/spec/views/contacts/destroy.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/contacts/destroy" do
   include ContactsHelper
 
   before do
-    login_and_assign
+    login
     assign(:contact, @contact = FactoryGirl.build_stubbed(:contact))
     assign(:contacts, [@contact].paginate)
   end

--- a/spec/views/contacts/edit.js.haml_spec.rb
+++ b/spec/views/contacts/edit.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/contacts/edit" do
   include ContactsHelper
 
   before do
-    login_and_assign
+    login
     assign(:contact, @contact = FactoryGirl.build_stubbed(:contact, user: current_user))
     assign(:users, [current_user])
     assign(:account, @account = FactoryGirl.build_stubbed(:account))

--- a/spec/views/contacts/index.haml_spec.rb
+++ b/spec/views/contacts/index.haml_spec.rb
@@ -15,7 +15,7 @@ describe "/contacts/index" do
     assign :per_page, Contact.per_page
     assign :sort_by,  Contact.sort_by
     assign :ransack_search, Contact.ransack
-    login_and_assign
+    login
   end
 
   it "should render a list of contacts if it's not empty" do

--- a/spec/views/contacts/index.js.html_spec.rb
+++ b/spec/views/contacts/index.js.html_spec.rb
@@ -11,7 +11,7 @@ describe "/contacts/index" do
   include ContactsHelper
 
   before do
-    login_and_assign
+    login
   end
 
   it "should render [contact] template with @contacts collection if there are contacts" do

--- a/spec/views/contacts/new.js.haml_spec.rb
+++ b/spec/views/contacts/new.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/contacts/new" do
   include ContactsHelper
 
   before do
-    login_and_assign
+    login
     @account = FactoryGirl.build_stubbed(:account)
     assign(:contact, Contact.new(user: current_user))
     assign(:users, [current_user])

--- a/spec/views/contacts/show.haml_spec.rb
+++ b/spec/views/contacts/show.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/contacts/show" do
   include ContactsHelper
 
   before do
-    login_and_assign
+    login
     @contact = FactoryGirl.create(:contact, id: 42,
                                             opportunities: [FactoryGirl.create(:opportunity)])
     assign(:contact, @contact)

--- a/spec/views/contacts/update.js.haml_spec.rb
+++ b/spec/views/contacts/update.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/contacts/update" do
   include ContactsHelper
 
   before do
-    login_and_assign
+    login
 
     assign(:contact, @contact = FactoryGirl.build_stubbed(:contact, user: current_user))
     assign(:users, [current_user])

--- a/spec/views/home/index.haml_spec.rb
+++ b/spec/views/home/index.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/home/index" do
   include HomeHelper
 
   before do
-    login_and_assign
+    login
   end
 
   it "should render list of activities if it's not empty" do

--- a/spec/views/home/index.js.haml_spec.rb
+++ b/spec/views/home/index.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/home/index" do
   include HomeHelper
 
   before do
-    login_and_assign!
+    login
   end
 
   it "should render [activity] template with @activities collection" do

--- a/spec/views/home/options.js.haml_spec.rb
+++ b/spec/views/home/options.js.haml_spec.rb
@@ -9,7 +9,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe "/home/options" do
   before do
-    login_and_assign
+    login
   end
 
   it "should render [options] template into :options div and show it" do

--- a/spec/views/leads/_convert.haml_spec.rb
+++ b/spec/views/leads/_convert.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/leads/_convert" do
   include LeadsHelper
 
   before do
-    login_and_assign
+    login
     @account = FactoryGirl.build_stubbed(:account)
     assign(:lead, FactoryGirl.build_stubbed(:lead))
     assign(:users, [current_user])

--- a/spec/views/leads/_edit.haml_spec.rb
+++ b/spec/views/leads/_edit.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/leads/_edit" do
   include LeadsHelper
 
   before do
-    login_and_assign
+    login
     assign(:lead, @lead = FactoryGirl.build_stubbed(:lead))
     assign(:users, [current_user])
     assign(:campaign, @campaign = FactoryGirl.build_stubbed(:campaign))

--- a/spec/views/leads/_new.haml_spec.rb
+++ b/spec/views/leads/_new.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/leads/_new" do
   include LeadsHelper
 
   before do
-    login_and_assign
+    login
     assign(:lead, FactoryGirl.build(:lead))
     assign(:users, [current_user])
     assign(:campaign, @campaign = FactoryGirl.build_stubbed(:campaign))

--- a/spec/views/leads/_sidebar_show.haml_spec.rb
+++ b/spec/views/leads/_sidebar_show.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/leads/_sidebar_show" do
   include LeadsHelper
 
   before do
-    login_and_assign
+    login
     assign(:users, [current_user])
     assign(:comment, Comment.new)
     assign(:lead, FactoryGirl.build_stubbed(:lead,

--- a/spec/views/leads/convert.js.haml_spec.rb
+++ b/spec/views/leads/convert.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/leads/convert" do
   include LeadsHelper
 
   before do
-    login_and_assign
+    login
 
     assign(:lead, @lead = FactoryGirl.build_stubbed(:lead, user: current_user))
     assign(:users, [current_user])

--- a/spec/views/leads/create.js.haml_spec.rb
+++ b/spec/views/leads/create.js.haml_spec.rb
@@ -10,7 +10,7 @@ require 'spec_helper'
 describe "/leads/create" do
   before do
     controller.controller_path = 'leads'
-    login_and_assign
+    login
     assign(:campaigns, [FactoryGirl.build_stubbed(:campaign)])
   end
 

--- a/spec/views/leads/destroy.js.haml_spec.rb
+++ b/spec/views/leads/destroy.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "/leads/destroy" do
   before do
-    login_and_assign
+    login
     assign(:lead, @lead = FactoryGirl.build_stubbed(:lead))
     assign(:lead_status_total, Hash.new(1))
   end

--- a/spec/views/leads/edit.js.haml_spec.rb
+++ b/spec/views/leads/edit.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/leads/edit" do
   include LeadsHelper
 
   before do
-    login_and_assign
+    login
     assign(:lead, @lead = FactoryGirl.build_stubbed(:lead, status: "new", user: current_user))
     assign(:users, [current_user])
     assign(:campaigns, [FactoryGirl.build_stubbed(:campaign)])

--- a/spec/views/leads/index.haml_spec.rb
+++ b/spec/views/leads/index.haml_spec.rb
@@ -15,7 +15,7 @@ describe "/leads/index" do
     assign :per_page, Lead.per_page
     assign :sort_by,  Lead.sort_by
     assign :ransack_search, Lead.ransack
-    login_and_assign
+    login
   end
 
   it "should render list of accounts if list of leads is not empty" do

--- a/spec/views/leads/index.js.haml_spec.rb
+++ b/spec/views/leads/index.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/leads/index" do
   include LeadsHelper
 
   before do
-    login_and_assign
+    login
   end
 
   it "should render [lead] template with @leads collection if there are leads" do

--- a/spec/views/leads/new.js.haml_spec.rb
+++ b/spec/views/leads/new.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/leads/new" do
   include LeadsHelper
 
   before do
-    login_and_assign
+    login
     @campaign = FactoryGirl.build_stubbed(:campaign)
     assign(:lead, Lead.new(user: current_user))
     assign(:users, [current_user])

--- a/spec/views/leads/promote.js.haml_spec.rb
+++ b/spec/views/leads/promote.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "/leads/promote" do
   before do
-    login_and_assign
+    login
     assign(:users, [current_user])
     assign(:account, @account = FactoryGirl.build_stubbed(:account))
     assign(:accounts, [@account])

--- a/spec/views/leads/reject.js.haml_spec.rb
+++ b/spec/views/leads/reject.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "/leads/reject" do
   before do
-    login_and_assign
+    login
     assign(:lead, @lead = FactoryGirl.build_stubbed(:lead, status: "new"))
     assign(:lead_status_total, Hash.new(1))
   end

--- a/spec/views/leads/show.haml_spec.rb
+++ b/spec/views/leads/show.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/leads/show" do
   include LeadsHelper
 
   before do
-    login_and_assign
+    login
     assign(:lead, @lead = FactoryGirl.build_stubbed(:lead, id: 42))
     assign(:users, [current_user])
     assign(:comment, Comment.new)

--- a/spec/views/leads/update.js.haml_spec.rb
+++ b/spec/views/leads/update.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "/leads/update" do
   before do
-    login_and_assign
+    login
     assign(:lead, @lead = FactoryGirl.build_stubbed(:lead, user: current_user, assignee: FactoryGirl.build_stubbed(:user)))
     assign(:users, [current_user])
     assign(:campaigns, [FactoryGirl.build_stubbed(:campaign)])

--- a/spec/views/opportunities/_edit.haml_spec.rb
+++ b/spec/views/opportunities/_edit.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/opportunities/_edit" do
   include OpportunitiesHelper
 
   before do
-    login_and_assign
+    login
     assign(:account, @account = FactoryGirl.build_stubbed(:account))
     assign(:accounts, [@account])
     assign(:stage, Setting.unroll(:opportunity_stage))

--- a/spec/views/opportunities/_new.haml_spec.rb
+++ b/spec/views/opportunities/_new.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/opportunities/_new" do
   include OpportunitiesHelper
 
   before do
-    login_and_assign
+    login
     assign(:opportunity, FactoryGirl.build(:opportunity))
     @account = FactoryGirl.build_stubbed(:account)
     assign(:account, @account)

--- a/spec/views/opportunities/create.js.haml_spec.rb
+++ b/spec/views/opportunities/create.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "/opportunities/create" do
   before do
-    login_and_assign
+    login
     assign(:stage, Setting.unroll(:opportunity_stage))
   end
 

--- a/spec/views/opportunities/destroy.js.haml_spec.rb
+++ b/spec/views/opportunities/destroy.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "/opportunities/destroy" do
   before do
-    login_and_assign
+    login
     assign(:opportunity, @opportunity = FactoryGirl.build_stubbed(:opportunity))
     assign(:stage, Setting.unroll(:opportunity_stage))
     assign(:opportunity_stage_total, Hash.new(1))

--- a/spec/views/opportunities/edit.js.haml_spec.rb
+++ b/spec/views/opportunities/edit.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/opportunities/edit" do
   include OpportunitiesHelper
 
   before do
-    login_and_assign
+    login
 
     assign(:opportunity, @opportunity = FactoryGirl.build_stubbed(:opportunity, user: current_user))
     assign(:users, [current_user])

--- a/spec/views/opportunities/index.haml_spec.rb
+++ b/spec/views/opportunities/index.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/opportunities/index" do
   include OpportunitiesHelper
 
   before do
-    login_and_assign
+    login
     view.lookup_context.prefixes << 'entities'
     assign :stage, Setting.unroll(:opportunity_stage)
     assign :per_page, Opportunity.per_page

--- a/spec/views/opportunities/index.js.haml_spec.rb
+++ b/spec/views/opportunities/index.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/opportunities/index" do
   include OpportunitiesHelper
 
   before do
-    login_and_assign
+    login
     assign(:stage, Setting.unroll(:opportunity_stage))
   end
 

--- a/spec/views/opportunities/new.js.haml_spec.rb
+++ b/spec/views/opportunities/new.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/opportunities/new" do
   include OpportunitiesHelper
 
   before do
-    login_and_assign
+    login
     @account = FactoryGirl.build_stubbed(:account)
     assign(:opportunity, Opportunity.new(user: current_user))
     assign(:users, [current_user])

--- a/spec/views/opportunities/show.haml_spec.rb
+++ b/spec/views/opportunities/show.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/opportunities/show" do
   include OpportunitiesHelper
 
   before do
-    login_and_assign
+    login
     @opportunity = FactoryGirl.create(:opportunity, id: 42,
                                                     contacts: [FactoryGirl.create(:contact)])
     assign(:opportunity, @opportunity)

--- a/spec/views/opportunities/update.js.haml_spec.rb
+++ b/spec/views/opportunities/update.js.haml_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 
 describe "/opportunities/update" do
   before do
-    login_and_assign
+    login
 
     assign(:opportunity, @opportunity = FactoryGirl.build_stubbed(:opportunity, user: current_user, assignee: FactoryGirl.build_stubbed(:user)))
     assign(:users, [current_user])

--- a/spec/views/tasks/_edit.haml_spec.rb
+++ b/spec/views/tasks/_edit.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/tasks/_edit" do
   include TasksHelper
 
   before do
-    login_and_assign
+    login
     assign(:task, FactoryGirl.build_stubbed(:task, asset: FactoryGirl.build_stubbed(:account), bucket: "due_asap"))
     assign(:users, [current_user])
     assign(:bucket, %w[due_asap due_today])

--- a/spec/views/tasks/complete.js.haml_spec.rb
+++ b/spec/views/tasks/complete.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/tasks/complete" do
   include TasksHelper
 
   before do
-    login_and_assign
+    login
     assign(:bucket, [])
   end
 

--- a/spec/views/tasks/create.js.haml_spec.rb
+++ b/spec/views/tasks/create.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/tasks/create" do
   include TasksHelper
 
   before do
-    login_and_assign
+    login
   end
 
   (TASK_STATUSES - ['completed']).each do |status|

--- a/spec/views/tasks/destroy.js.haml_spec.rb
+++ b/spec/views/tasks/destroy.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/tasks/destroy" do
   include TasksHelper
 
   before do
-    login_and_assign
+    login
   end
 
   TASK_STATUSES.each do |status|

--- a/spec/views/tasks/edit.js.haml_spec.rb
+++ b/spec/views/tasks/edit.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/tasks/edit" do
   include TasksHelper
 
   before do
-    login_and_assign
+    login
     assign(:users, [current_user])
     assign(:bucket, Setting.task_bucket[1..-1] << ["On Specific Date...", :specific_time])
     assign(:category, Setting.unroll(:task_category))

--- a/spec/views/tasks/index.haml_spec.rb
+++ b/spec/views/tasks/index.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/tasks/index" do
   include TasksHelper
 
   before do
-    login_and_assign
+    login
   end
 
   TASK_STATUSES.each do |status|

--- a/spec/views/tasks/new.js.haml_spec.rb
+++ b/spec/views/tasks/new.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/tasks/new" do
   include TasksHelper
 
   before do
-    login_and_assign
+    login
     assign(:task, FactoryGirl.build(:task))
     assign(:users, [current_user])
     assign(:bucket, Setting.task_bucket[1..-1] << ["On Specific Date...", :specific_time])

--- a/spec/views/tasks/uncomplete.js.haml_spec.rb
+++ b/spec/views/tasks/uncomplete.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/tasks/uncomplete" do
   include TasksHelper
 
   before do
-    login_and_assign
+    login
     assign(:bucket, [])
   end
 

--- a/spec/views/tasks/update.js.haml_spec.rb
+++ b/spec/views/tasks/update.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/tasks/update" do
   include TasksHelper
 
   before do
-    login_and_assign
+    login
   end
 
   describe "Changing due date" do

--- a/spec/views/users/avatar.js.haml_spec.rb
+++ b/spec/views/users/avatar.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/users/avatar" do
   include UsersHelper
 
   before do
-    login_and_assign
+    login
     assign(:user, current_user)
   end
 

--- a/spec/views/users/change_password.js.haml_spec.rb
+++ b/spec/views/users/change_password.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/users/change_password" do
   include UsersHelper
 
   before do
-    login_and_assign
+    login
     assign(:user, @user = current_user)
   end
 

--- a/spec/views/users/edit.js.haml_spec.rb
+++ b/spec/views/users/edit.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/users/edit" do
   include UsersHelper
 
   before do
-    login_and_assign
+    login
     assign(:user, @user = current_user)
   end
 

--- a/spec/views/users/password.js.haml_spec.rb
+++ b/spec/views/users/password.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/users/password" do
   include UsersHelper
 
   before do
-    login_and_assign
+    login
     assign(:user, current_user)
   end
 

--- a/spec/views/users/update.js.haml_spec.rb
+++ b/spec/views/users/update.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/users/update" do
   include UsersHelper
 
   before do
-    login_and_assign
+    login
     assign(:user, @user = current_user)
   end
 

--- a/spec/views/users/upload_avatar.js.haml_spec.rb
+++ b/spec/views/users/upload_avatar.js.haml_spec.rb
@@ -11,7 +11,7 @@ describe "/users/upload_avatar" do
   include UsersHelper
 
   before do
-    login_and_assign
+    login
   end
 
   describe "no errors:" do
@@ -33,7 +33,7 @@ describe "/users/upload_avatar" do
     before do
       @avatar = FactoryGirl.build_stubbed(:avatar, entity: current_user)
       @avatar.errors.add(:image, "error")
-      allow(current_user).to receive(:avatar).and_return(@avatar)
+      allow_any_instance_of(User).to receive(:avatar).and_return(@avatar)
       assign(:user, @user = current_user)
     end
 


### PR DESCRIPTION
This PR simplifies the spec helper login macros of Authlogic to match Devise, and makes a few spec changes to reduce changes needed on devise branch.

In this PR I have deleted two specs which are re-added by #671. This is intentional and the code from #671 should be used to resolve the conflict.