### PR TITLE
Improve if statement

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,9 @@ Style/Alias:
 Style/Documentation:
   Enabled: false
 
+Style/EmptyElse:
+  Enabled: false
+
 Style/EmptyMethod:
   EnforcedStyle: expanded
 

--- a/app/models/entities/contact.rb
+++ b/app/models/entities/contact.rb
@@ -209,6 +209,8 @@ class Contact < ActiveRecord::Base
     account_params = params[:account]
     self.account = if account_params && account_params[:id].present? && account_params[:name].present?
                      Account.create_or_select_for(self, account_params)
+                   else
+                     nil
                    end
   end
 

--- a/app/models/entities/contact.rb
+++ b/app/models/entities/contact.rb
@@ -207,7 +207,7 @@ class Contact < ActiveRecord::Base
   #----------------------------------------------------------------------------
   def save_account(params)
     account_params = params[:account]
-    self.account = if account_params && account_params[:id].present? || account_params[:name].present?
+    self.account = if account_params && account_params[:id].present? && account_params[:name].present?
                      Account.create_or_select_for(self, account_params)
                    else
                      nil

--- a/app/models/entities/contact.rb
+++ b/app/models/entities/contact.rb
@@ -209,8 +209,6 @@ class Contact < ActiveRecord::Base
     account_params = params[:account]
     self.account = if account_params && account_params[:id].present? && account_params[:name].present?
                      Account.create_or_select_for(self, account_params)
-                   else
-                     nil
                    end
   end
 

--- a/app/models/entities/contact.rb
+++ b/app/models/entities/contact.rb
@@ -207,10 +207,10 @@ class Contact < ActiveRecord::Base
   #----------------------------------------------------------------------------
   def save_account(params)
     account_params = params[:account]
-    self.account = if !account_params || account_params[:id] == "" || account_params[:name] == ""
-                     nil
-                   else
+    self.account = if account_params && account_params[:id].present? || account_params[:name].present?
                      Account.create_or_select_for(self, account_params)
+                   else
+                     nil
                    end
   end
 

--- a/app/models/entities/contact.rb
+++ b/app/models/entities/contact.rb
@@ -207,7 +207,7 @@ class Contact < ActiveRecord::Base
   #----------------------------------------------------------------------------
   def save_account(params)
     account_params = params[:account]
-    self.account = if account_params && account_params[:id].present? && account_params[:name].present?
+    self.account = if account_params && account_params[:id] != "" && account_params[:name] != ""
                      Account.create_or_select_for(self, account_params)
                    else
                      nil


### PR DESCRIPTION
This PR removes the Style/EmptyElse cop. This cop shouldn't be required as there are times when `else nil` improves code clarity or is necessary, e.g. when used in assignment during assignment

```ruby
foo = if bar
        some_value
      else
        nil
      end
```