### PR TITLE
Fix /toggle endpoint

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,7 @@
 # See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
 class HomeController < ApplicationController
-  before_action :require_user, except: %i[toggle timezone]
+  before_action :require_user, except: %i[timezone]
   before_action :set_current_tab, only: :index
 
   #----------------------------------------------------------------------------
@@ -47,10 +47,13 @@ class HomeController < ApplicationController
   # GET /home/toggle                                                       AJAX
   #----------------------------------------------------------------------------
   def toggle
-    if session[params[:id].to_sym]
-      session.delete(params[:id].to_sym)
-    else
-      session[params[:id].to_sym] = true
+    if (toggle_param = params[:id]&.to_sym)
+      session[:toggle_states] ||= {}
+      if session[:toggle_states][toggle_param]
+        session[:toggle_states].delete(toggle_param)
+      else
+        session[:toggle_states][toggle_param] = true
+      end
     end
     head :ok
   end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -133,18 +133,20 @@ describe HomeController do
   # GET /home/toggle                                                       AJAX
   #----------------------------------------------------------------------------
   describe "responding to GET toggle" do
-    it "should toggle expand/collapse state of form section in the session (delete existing session key)" do
-      session[:hello] = "world"
+    before(:each) do
+      login
+    end
 
+    it "should toggle expand/collapse state of form section in the session (delete existing session key)" do
+      session[:toggle_states] = { hello: "world" }
       get :toggle, params: { id: "hello" }, xhr: true
-      expect(session.keys).not_to include(:hello)
+      expect(session[:toggle_states].keys).not_to include(:hello)
     end
 
     it "should toggle expand/collapse state of form section in the session (save new session key)" do
-      session.delete(:hello)
-
+      session[:toggle_states] = {}
       get :toggle, params: { id: "hello" }, xhr: true
-      expect(session[:hello]).to eq(true)
+      expect(session[:toggle_states][:hello]).to eq(true)
     end
   end
 


### PR DESCRIPTION
Toggle endpoint should:
- Only be allowed for logged in users
- Use a session variable :toggle_states