### PR TITLE
Remove redundant escape

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -482,7 +482,7 @@ module ApplicationHelper
     return unless time
     options[:class] ||= "timeago"
     options[:title] = time.getutc.iso8601
-    content_tag(:span, h(I18n.l(time)), options).html_safe
+    content_tag(:span, I18n.l(time), options)
   end
 
   #----------------------------------------------------------------------------


### PR DESCRIPTION
Improvement on #697. `content_tag` method automatically escapes the inner text and returns an html_safe string.