### PR TITLE
Fewer images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ matrix:
     - rvm: 2.5.0
       env: DB=mysql TEST_SUITE="rake spec:models"
     - rvm: 2.5.0
-      env: DB=postgres TEST_SUITE="rake spec:models"
-    - rvm: 2.5.0
       env: DB=sqlite TEST_SUITE="rake spec:models"
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,8 @@ env:
     - DB=postgres TEST_SUITE=rubocop
     - DB=postgres TEST_SUITE="rake spec:features"
     - DB=postgres TEST_SUITE="rake spec:models"
-    - DB=postgres TEST_SUITE="rake spec:mailers"
-    - DB=postgres TEST_SUITE="rake spec:controllers"
-    - DB=postgres TEST_SUITE="rake spec:helpers"
-    - DB=postgres TEST_SUITE="rake spec:lib"
-    - DB=postgres TEST_SUITE="rake spec:routing"
-    - DB=postgres TEST_SUITE="rake spec:views"
+    - DB=postgres TEST_SUITE="rake spec:controllers spec:lib spec:routing spec:mailers"
+    - DB=postgres TEST_SUITE="rake spec:views spec:helpers"
     - DB=mysql TEST_SUITE="rake spec:models"
     - DB=sqlite TEST_SUITE="rake spec:models"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ env:
 
 matrix:
   fast_finish: true
+  exclude:
+    - rvm: 2.5.0
+      env: DB=postgres TEST_SUITE=rubocop
   allow_failures:
     - rvm: 2.4.2
       env: DB=mysql TEST_SUITE="rake spec:models"


### PR DESCRIPTION
Consolidates some of the smaller, less flakey builds together so we skip the overhead of provisioning machines; but keeps features / models as seperate builds.

We still have the high wait time (prior to this, build execution was ~10 minutes but wait time was ~45 minutes, typically); this should require less images so in theory a shorter wait time.