### PR TITLE
bundle install fails for fresh app

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
       factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     ffaker (2.8.1)
-    ffi (1.9.21)
+    ffi (1.9.23)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake


### PR DESCRIPTION
Tested on:
*MacOS High Sierra 10.13.3
*rbenv 1.1.0
*ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-darwin16]
*Bundler version 1.16.1

#### Steps to reproduce:
1. Clone fresh copy of the app
2. run `bundle install`
3. Note bundler blows up with this error:
```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/malachai/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/ffi-1.9.21/ext/ffi_c
/Users/malachai/.rbenv/versions/2.4.2/bin/ruby -r ./siteconf20180326-20827-1q7q9n5.rb extconf.rb
checking for ffi.h... no
checking for ffi.h in /usr/local/include,/usr/include/ffi... no
checking for shlwapi.h... no
checking for rb_thread_blocking_region()... no
checking for rb_thread_call_with_gvl()... yes
checking for rb_thread_call_without_gvl()... yes
creating extconf.h
creating Makefile

current directory: /Users/malachai/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/ffi-1.9.21/ext/ffi_c
make "DESTDIR=" clean

current directory: /Users/malachai/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/ffi-1.9.21/ext/ffi_c
make "DESTDIR="
Running autoreconf for libffi
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal -I m4 --output=aclocal.m4t
Can't exec "aclocal": No such file or directory at /usr/local/Cellar/autoconf/2.69/share/autoconf/Autom4te/FileUtils.pm line 326.
autoreconf: failed to run aclocal: No such file or directory
make: *** ["/Users/malachai/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/ffi-1.9.21/ext/ffi_c/libffi-x86_64-darwin16"/.libs/libffi_convenience.a] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/malachai/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/ffi-1.9.21 for inspection.
Results logged to /Users/malachai/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/extensions/x86_64-darwin-16/2.4.0-static/ffi-1.9.21/gem_make.out

An error occurred while installing ffi (1.9.21), and Bundler cannot continue.
Make sure that `gem install ffi -v '1.9.21'` succeeds before bundling.

In Gemfile:
  authlogic was resolved to 3.8.0, which depends on
    scrypt was resolved to 3.0.5, which depends on
      ffi-compiler was resolved to 1.0.1, which depends on
        ffi
```

#### Le Fix: (Note: https://github.com/ffi/ffi/issues/607)
1. run `bundle update rb-fchange`
2. Verify `Using ffi 1.9.23 (was 1.9.21)`
