### PR TITLE
Escape account name for javascript in edit/update js views.

### DIFF
--- a/app/views/accounts/edit.js.haml
+++ b/app/views/accounts/edit.js.haml
@@ -28,4 +28,4 @@
   - elsif params[:cancel].false?                    # Called from title of the landing page...
     $('#edit_#{entity_name}').html('#{ j render(partial: "edit") }');
     crm.flip_form('edit_#{entity_name}');
-    crm.set_title('edit_#{entity_name}', "#{t :edit} #{h @entity.name}");
+    crm.set_title('edit_#{entity_name}', "#{t :edit} #{j @entity.name}");

--- a/app/views/accounts/update.js.haml
+++ b/app/views/accounts/update.js.haml
@@ -5,7 +5,7 @@
 - if @entity.errors.empty?
   - if called_from_landing_page?
     crm.flip_form('edit_#{entity_name}');
-    crm.set_title('edit_#{entity_name}', '#{h @entity.name}');
+    crm.set_title('edit_#{entity_name}', '#{j @entity.name}');
     = refresh_sidebar(:show, :summary)
   - else
     $('##{id}').replaceWith('#{ j render(partial: entity_name, collection: [ @entity ]) }');


### PR DESCRIPTION
This fixes a bug with `\` character in account name blocking an account from edits.