### PR TITLE
removed instruction to put unicorn as default in Procfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ end
 
 group :heroku do
   gem 'rails_12factor'
+  gem 'puma'
 end
 
 gem 'sass-rails'

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec puma -C config/puma.rb

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb

--- a/lib/tasks/ffcrm/setup.rake
+++ b/lib/tasks/ffcrm/setup.rake
@@ -77,7 +77,7 @@ namespace :ffcrm do
       User.reset_column_information # Reload the class since we've added new fields in migrations.
       user = User.find_by_username(username) || User.new
       user.skip_confirmation!
-      user.confirm!
+      user.confirm
       user.update_attributes(username: username, password: password, email: email)
       user.update_attribute(:confirmed_at, Time.now.utc) # Skip confirmation
       user.update_attribute(:admin, true) # Mass assignments don't work for :admin because of the attr_protected

--- a/lib/tasks/ffcrm/setup.rake
+++ b/lib/tasks/ffcrm/setup.rake
@@ -76,6 +76,8 @@ namespace :ffcrm do
       end
       User.reset_column_information # Reload the class since we've added new fields in migrations.
       user = User.find_by_username(username) || User.new
+      user.skip_confirmation!
+      user.confirm!
       user.update_attributes(username: username, password: password, email: email)
       user.update_attribute(:confirmed_at, Time.now.utc) # Skip confirmation
       user.update_attribute(:admin, true) # Mass assignments don't work for :admin because of the attr_protected


### PR DESCRIPTION
I followed these instructions without loading sample data. 

https://github.com/fatfreecrm/fat_free_crm/wiki/Setup-Heroku

Code pushes to heroku, app starts, but then crashes. Restart seems to go fine until first request. I believe the issue is this instruction in the Procfile:

`web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb
`

However according to the changelog:

`- #641 Swap default server from thin/unicorn to puma
`

I removed the line in the procfile (but left the empty prrocfile) and it seems to run. Here's a pull request with the change:

https://github.com/fatfreecrm/fat_free_crm/pull/782
