### PR TITLE
Change prompts from Note to Comment

### DIFF
--- a/config/locales/fat_free_crm.en-GB.yml
+++ b/config/locales/fat_free_crm.en-GB.yml
@@ -593,10 +593,10 @@ en-GB:
 
   # Views -> Common.
   #----------------------------------------------------------------------------
-  add_note: Add Note
-  save_note: Save Note
-  add_note_help: Add a new note...
-  edit_note: Edit Note
+  add_note: Add Comment
+  save_note: Save Comment
+  add_note_help: Add a new comment...
+  edit_note: Edit Comment
   added_ago: added %{value}
   added_by: added %{time_ago} by %{user}
   back: Back
@@ -682,7 +682,7 @@ en-GB:
   notifications_tooltip: Subscribers will receive new comments via email
   subscribe_via_email: Subscribe via email
   disable_email_subscriptions: Disable email subscription
-  added_note: added note %{value}
+  added_note: added comment %{value}
 
   # Views -> Emails.
   #----------------------------------------------------------------------------

--- a/config/locales/fat_free_crm.en-US.yml
+++ b/config/locales/fat_free_crm.en-US.yml
@@ -593,10 +593,10 @@ en-US:
 
   # Views -> Common.
   #----------------------------------------------------------------------------
-  add_note: Add Note
-  save_note: Save Note
-  add_note_help: Add a new note...
-  edit_note: Edit Note
+  add_note: Add Comment
+  save_note: Save Comment
+  add_note_help: Add a new comment...
+  edit_note: Edit Comment
   added_ago: added %{value}
   added_by: added %{time_ago} by %{user}
   back: Back
@@ -682,7 +682,7 @@ en-US:
   notifications_tooltip: Subscribers will receive new comments via email
   subscribe_via_email: Subscribe via email
   disable_email_subscriptions: Disable email subscription
-  added_note: added note %{value}
+  added_note: added comment %{value}
 
   # Views -> Emails.
   #----------------------------------------------------------------------------

--- a/spec/features/opportunities_spec.rb
+++ b/spec/features/opportunities_spec.rb
@@ -120,13 +120,13 @@ feature 'Opportunities', '
     expect(find('#opportunities')).not_to have_content("Opportunity 1")
   end
 
-  scenario 'should add note to opportunity', js: true do
+  scenario 'should add comment to opportunity', js: true do
     opportunity = create(:opportunity, name: 'Awesome Opportunity')
     visit opportunities_page
     click_link 'Awesome Opportunity'
     find("#opportunity_#{opportunity.id}_post_new_note").click
     fill_in 'comment[comment]', with: 'Most awesome opportunity'
-    click_button 'Add Note'
+    click_button 'Add Comment'
     expect(page).to have_content('Most awesome opportunity')
   end
 end


### PR DESCRIPTION
Fixes issue #737 

It was a little simpler than I expected. The application has done a great job of localizing buttons and labels. I modified the two .yml files that pertain to english and migrated Notes to Comments.

For example: 
![screen shot 2018-06-07 at 8 37 06 pm](https://user-images.githubusercontent.com/24664863/41137907-a754ba1c-6a92-11e8-859c-458e54bb876a.png)

![screen shot 2018-06-07 at 8 37 21 pm](https://user-images.githubusercontent.com/24664863/41137909-aab41ff4-6a92-11e8-8862-7ec5e6c19679.png)


I did not modify any models. Please let me know if there are any further changes.

