### PR TITLE
Update devise to 4.4.0 in gemspec

### DIFF
--- a/fat_free_crm.gemspec
+++ b/fat_free_crm.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'will_paginate'
   gem.add_dependency 'paperclip'
   gem.add_dependency 'paper_trail',         '~> 6.0.0'
-  gem.add_dependency 'devise',              '~> 4.3.0'
+  gem.add_dependency 'devise',              '~> 4.4.0'
   gem.add_dependency 'devise-encryptable',  '~> 0.2.0'
   gem.add_dependency 'acts_as_commentable'
   gem.add_dependency 'acts-as-taggable-on', '>= 3.4.3'


### PR DESCRIPTION
The Gemfile locks devise to '~> 4.4.0'. The fat_free_crm.gemspec locks devise to '~> 4.3.0'. 

This causes ffr to fail when used as a gem (eg Engine), under Ruby 2.5.x (which is not compatible with devise 4.3.0)