### PR TITLE
Fixed bug for creating account when creating new contact

### DIFF
--- a/app/models/entities/contact.rb
+++ b/app/models/entities/contact.rb
@@ -207,7 +207,8 @@ class Contact < ActiveRecord::Base
   #----------------------------------------------------------------------------
   def save_account(params)
     account_params = params[:account]
-    self.account = if account_params && account_params[:id] != "" && account_params[:name] != ""
+    valid_account = account_params && (account_params[:id].present? || account_params[:name].present?)
+    self.account = if valid_account
                      Account.create_or_select_for(self, account_params)
                    else
                      nil

--- a/spec/controllers/entities/contacts_controller_spec.rb
+++ b/spec/controllers/entities/contacts_controller_spec.rb
@@ -334,7 +334,7 @@ describe ContactsController do
         @contact = build(:contact, first_name: "Billy", last_name: "Bones")
         allow(Contact).to receive(:new).and_return(@contact)
 
-        post :create, params: { contact: { first_name: "Billy", last_name: "Bones" }, account: { name: "Hello world" } }, xhr: true
+        post :create, params: { contact: { first_name: "Billy", last_name: "Bones" }, account: { id: "", name: "Hello world" } }, xhr: true
         expect(assigns(:contact)).to eq(@contact)
         expect(assigns(:contact).reload.account.name).to eq("Hello world")
         expect(response).to render_template("contacts/create")


### PR DESCRIPTION
When you create a new contact, you have the option of creating a new account as well. This does not work for me when running the CRM.

Reason:
The page submits the account[id] as an empty string. This will cause  app/models/entities/contact.rb:210 to return false on the account_params[:id] != "". The rspec however, does not send the id at all. Thus, the expression returns true, since account_params[:id] == nil.

Proof:
Once you change the rspec and submit an empty id, the rspec will fail.

Resolution:
Either id or name must be present. (app/models/entities/contact.rb:210)