### PR TITLE
Fixed bug that sets the user of an account when the account is created through the creation of a contact

### DIFF
--- a/app/models/entities/account.rb
+++ b/app/models/entities/account.rb
@@ -119,12 +119,15 @@ class Account < ActiveRecord::Base
     # Attempt to find existing account
     if params[:id].present?
       return Account.find(params[:id])
-    elsif params[:name].present?
+    end
+
+    if params[:name].present?
       account = Account.find_by(name: params[:name])
       return account if account
     end
 
     # Fallback to create new account
+    params[:user] = model.user if model
     account = Account.new(params)
     if account.access != "Lead" || model.nil?
       account.save

--- a/spec/controllers/entities/contacts_controller_spec.rb
+++ b/spec/controllers/entities/contacts_controller_spec.rb
@@ -337,6 +337,7 @@ describe ContactsController do
         post :create, params: { contact: { first_name: "Billy", last_name: "Bones" }, account: { name: "Hello world" } }, xhr: true
         expect(assigns(:contact)).to eq(@contact)
         expect(assigns(:contact).reload.account.name).to eq("Hello world")
+        expect(assigns(:contact).account.user).to eq(assigns(:contact).user)
         expect(response).to render_template("contacts/create")
       end
 

--- a/spec/models/entities/account_spec.rb
+++ b/spec/models/entities/account_spec.rb
@@ -34,6 +34,33 @@ describe Account do
     Account.create!(name: "Test Account")
   end
 
+  describe "Creating or selecting" do
+    it "must create a new account" do
+      @account = Account.create_or_select_for(nil, name: "Account T")
+
+      expect(Account.count).to eq(1)
+      expect(Account.first).to eq(@account)
+    end
+
+    it "must select an existing account based on id" do
+      @account = create(:account)
+
+      expect(Account.create_or_select_for(nil, id: @account.id)).to eq(@account)
+    end
+
+    it "must select an existing account based on name" do
+      @account = create(:account)
+
+      expect(Account.create_or_select_for(nil, name: @account.name)).to eq(@account)
+    end
+
+    it "must create a new account based on existing model" do
+      @contact = create(:contact)
+      @account = Account.create_or_select_for(@contact, name: "Account T")
+      expect(@account.user).to eq(@contact.user)
+    end
+  end
+
   describe "Attach" do
     before do
       @account = create(:account)


### PR DESCRIPTION
When you create a new contact, you have the option of creating a new account as well. This does set the user for the contact, but it does not set the user for the account.

Reason:
When creating an account, the user_id parameter is not set in the account model.

Proof:
see assertion in spec/controllers/entities/contacts_contoller_spec.rb

Resolution:
Use the user from the provided model. (app/modles/entities/account.rb:128)