### PR TITLE
Contact created through lead contains user

### DIFF
--- a/app/models/entities/contact.rb
+++ b/app/models/entities/contact.rb
@@ -160,7 +160,7 @@ class Contact < ActiveRecord::Base
   def self.create_for(model, account, opportunity, params)
     attributes = {
       lead_id:     model.id,
-      user_id:     params[:account][:user_id],
+      user_id:     params[:account][:user_id] || account.user_id,
       assigned_to: params[:account][:assigned_to],
       access:      params[:access]
     }

--- a/spec/models/entities/contact_spec.rb
+++ b/spec/models/entities/contact_spec.rb
@@ -41,8 +41,18 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Contact do
+  let(:user) { create(:user) }
+
   it "should create a new instance given valid attributes" do
-    Contact.create!(first_name: "Billy", last_name: "Bones")
+    Contact.create!(first_name: "Billy", last_name: "Bones", user: user)
+  end
+
+  it "must create a new instance for a given model" do
+    lead = create(:lead)
+    account = create(:account)
+    opportunity = create(:opportunity)
+    @contact = Contact.create_for(lead, account, opportunity, account: {})
+    expect(@contact.valid?).to eq true
   end
 
   describe "Update existing contact" do


### PR DESCRIPTION
When a contact is created through a lead, the spec/controllers/entities/leads_controller_spec.rb does not create the user. This patch resolves this issue by using the user_id from the account model if the params does not supply a user_id.