### PR TITLE
Install tzdata in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ADD . /home/app
 WORKDIR /home/app
 
 RUN apt-get update \
-  && apt-get install -y imagemagick firefox \
+  && apt-get install -y imagemagick firefox tzdata \
   && apt-get autoremove -y \
   && cp config/database.postgres.docker.yml config/database.yml \
   && chown -R app:app /home/app \


### PR DESCRIPTION
System timezone data is needed. This fixes this error message:

    Error: The application encountered the following error: tzinfo-data is not
    present. Please add gem 'tzinfo-data' to your Gemfile and run bundle
    install (TZInfo::DataSourceNotFound)