### PR TITLE
Always load gravatar images over HTTPS

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -303,7 +303,7 @@ module ApplicationHelper
 
   # Entities can have associated avatars or gravatars. Only calls Gravatar
   # in production env. Gravatar won't serve default images if they are not
-  # publically available: http://en.gravatar.com/site/implement/images
+  # publically available: https://en.gravatar.com/site/implement/images
   #----------------------------------------------------------------------------
   def avatar_for(model, args = {})
     args = { class: 'gravatar', size: :large }.merge(args)

--- a/app/views/users/_avatar.html.haml
+++ b/app/views/users/_avatar.html.haml
@@ -11,7 +11,7 @@
       %div= a.file_field :image
 
     .buttonbar
-      %small.cool{style: "float:right"}== #{t :gravatar_help} #{link_to(t(:here), "http://en.gravatar.com", :"data-popup" => true)}.
+      %small.cool{style: "float:right"}== #{t :gravatar_help} #{link_to(t(:here), "https://en.gravatar.com", :"data-popup" => true)}.
       = f.submit t(:upload_picture), id: "user_avatar_submit"
       #{t :or}
       = link_to(t(:use_gravatar), upload_avatar_user_path(@user) + '?gravatar=1', method: :put, remote: true)

--- a/config/initializers/gravatar.rb
+++ b/config/initializers/gravatar.rb
@@ -10,5 +10,4 @@ GravatarImageTag.configure do |config|
   config.filetype      = nil   # Set this if you require a specific image file format ['gif', 'jpg' or 'png'].  Gravatar's default is png
   config.rating        = nil   # Set this if you change the rating of the images that will be returned ['G', 'PG', 'R', 'X']. Gravatar's default is G
   config.size          = nil   # Set this to globally set the size of the gravatar image returned (1..512). Gravatar's default is 80
-  config.secure        = false # Set this to true if you require secure images on your pages.
 end

--- a/lib/gravatar_image_tag.rb
+++ b/lib/gravatar_image_tag.rb
@@ -38,7 +38,7 @@ module GravatarImageTag
       rating:      GravatarImageTag.configuration.rating,
       size:        GravatarImageTag.configuration.size
     }.merge(overrides).delete_if { |_key, value| value.nil? }
-    "#{gravatar_url_base()}/#{gravatar_id(email, gravatar_params.delete(:filetype))}#{url_params(gravatar_params)}"
+    "#{gravatar_url_base}/#{gravatar_id(email, gravatar_params.delete(:filetype))}#{url_params(gravatar_params)}"
   end
 
   private

--- a/lib/gravatar_image_tag.rb
+++ b/lib/gravatar_image_tag.rb
@@ -14,7 +14,7 @@ module GravatarImageTag
   end
 
   class Configuration
-    attr_accessor :default_image, :filetype, :rating, :size, :secure
+    attr_accessor :default_image, :filetype, :rating, :size
    end
 
   def self.included(base)
@@ -36,16 +36,15 @@ module GravatarImageTag
       default:     GravatarImageTag.configuration.default_image,
       filetype:    GravatarImageTag.configuration.filetype,
       rating:      GravatarImageTag.configuration.rating,
-      secure:      GravatarImageTag.configuration.secure,
       size:        GravatarImageTag.configuration.size
     }.merge(overrides).delete_if { |_key, value| value.nil? }
-    "#{gravatar_url_base(gravatar_params.delete(:secure))}/#{gravatar_id(email, gravatar_params.delete(:filetype))}#{url_params(gravatar_params)}"
+    "#{gravatar_url_base()}/#{gravatar_id(email, gravatar_params.delete(:filetype))}#{url_params(gravatar_params)}"
   end
 
   private
 
-  def self.gravatar_url_base(secure = false)
-    'http' + (!!secure ? 's://secure.' : '://') + 'gravatar.com/avatar'
+  def self.gravatar_url_base()
+    'https://gravatar.com/avatar'
   end
 
   def self.gravatar_id(email, filetype = nil)

--- a/lib/gravatar_image_tag.rb
+++ b/lib/gravatar_image_tag.rb
@@ -43,7 +43,7 @@ module GravatarImageTag
 
   private
 
-  def self.gravatar_url_base()
+  def self.gravatar_url_base
     'https://gravatar.com/avatar'
   end
 


### PR DESCRIPTION
Loading images over HTTP breaks HTTPS sites, but not the other way around.
Remove the `secure` option and always load Gravatar images over HTTPS, since it
always works and is slightly more secure.