### PR TITLE
Changed exposed Ports for Rails up. App is wasn't available on 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 # Usage:
+# docker volume create pgdata
+# docker volume create gems
 # docker-compose up
 # docker-compose exec web bundle exec rake db:create db:schema:load ffcrm:demo:load
 
@@ -25,6 +27,8 @@ CMD ["bundle","exec","rails","s"]
 EXPOSE 3000
 
 # # Usage:
+# # docker volume create pgdata
+# # docker volume create gems
 # # docker-compose up
 # # docker-compose exec web bundle exec rake db:create db:schema:load ffcrm:demo:load assets:precompile
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     links:
       - db
     ports:
+      - "3000:3000"
       - "80:80"
     volumes:
       - gems:/usr/local/rvm/gems
@@ -18,5 +19,9 @@ services:
       DB_PORT: 5432
   db:
     image: postgres:9.5
+    restart: always
+    volumes:
+      - pgdata:/var/lib/postgresql/data
 volumes:
+  pgdata: {}
   gems: {}


### PR DESCRIPTION
In attempts to get the application up through docker-compose, I faced with a situation that CRM wasn't available on the local port, as a result of that I introduced fix and exposed native rails port which is 3000

In addition, a re-creation of databases takes time, as a result of that I introduced declared docker volume to store already created the database in PostgreSQL.

