### PR TITLE
campaignのstatusカラムをnull falseに修正

### DIFF
--- a/app/models/entities/campaign.rb
+++ b/app/models/entities/campaign.rb
@@ -14,7 +14,7 @@
 #  assigned_to         :integer
 #  name                :string(64)      default(""), not null
 #  access              :string(8)       default("Public")
-#  status              :string(64)
+#  status              :string(64)      not null
 #  budget              :decimal(12, 2)
 #  target_leads        :integer
 #  target_conversion   :float
@@ -65,7 +65,7 @@ class Campaign < ActiveRecord::Base
   validates_uniqueness_of :name, scope: %i[user_id deleted_at]
   validate :start_and_end_dates
   validate :users_for_shared_access
-  validates :status, inclusion: { in: proc { Setting.unroll(:campaign_status).map { |s| s.last.to_s } } }, allow_blank: true
+  validates :status, inclusion: { in: proc { Setting.unroll(:campaign_status).map { |s| s.last.to_s } } }, presence: true
 
   # Default values provided through class methods.
   #----------------------------------------------------------------------------

--- a/db/migrate/20100928030605_create_campaigns.rb
+++ b/db/migrate/20100928030605_create_campaigns.rb
@@ -8,7 +8,7 @@ class CreateCampaigns < ActiveRecord::Migration[4.2]
       t.integer :assigned_to
       t.string :name,   limit: 64, null: false, default: ""
       t.string :access, limit: 8, default: "Public" # %w(Private Public Shared)
-      t.string :status, limit: 64
+      t.string :status, limit: 64, null: false
       t.decimal :budget, precision: 12, scale: 2
       # Target metrics.
       t.integer :target_leads


### PR DESCRIPTION
## 概要
campaignテーブルで、statusがnullのデータを作成するとviewで以下のようなエラーが表示されます。

<img width="1245" alt="スクリーンショット 2019-05-14 11 38 19" src="https://user-images.githubusercontent.com/40588327/58222433-facb6480-7d50-11e9-8d79-c7e574abb741.png">

campaignのstatusは、常に何かしらの状態であるべきだと判断して
nullは許可しないように変更しました。

## 修正
- statusカラムにnull: falseを追加
- campaign.rbのvalidates :statusをpresence: trueに変更