### PR TITLE
Update tests to avoid travis error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,3 +61,5 @@ notifications:
 dist: xenial
 services:
   - xvfb
+  - postgresql
+  - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,6 @@ bundler_args: --path=vendor/bundle --without heroku
 
 cache: bundler
 
-before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-
 before_script:
   # gem update --system is a workaround for travis-ci/travis-ci#8978
   - "gem update --system"
@@ -61,3 +57,7 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
+
+dist: xenial
+services:
+  - xvfb


### PR DESCRIPTION
$ sh -e /etc/init.d/xvfb start
sh: 0: Can't open /etc/init.d/xvfb
The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .