### PR TITLE
Remove acts_as_fu

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ source 'https://rubygems.org'
 
 case ENV['CI'] && ENV['DB']
 when 'sqlite'
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.13'
 when 'mysql'
   gem 'mysql2'
 when 'postgres'
@@ -76,9 +76,9 @@ group :test do
   gem 'selenium-webdriver'
   gem 'chromedriver-helper'
   gem 'database_cleaner'
-  gem 'acts_as_fu'
   gem 'zeus', platform: :ruby unless ENV["CI"]
   gem 'timecop'
+  gem 'sqlite3', '~> 1.3.13'
 end
 
 group :heroku do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,9 +45,6 @@ GEM
     acts-as-taggable-on (6.0.0)
       activerecord (~> 5.0)
     acts_as_commentable (4.0.2)
-    acts_as_fu (0.0.9)
-      activerecord
-      sqlite3
     acts_as_list (1.0.0)
       activerecord (>= 4.2)
     addressable (2.7.0)
@@ -139,7 +136,7 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    guard (2.16.0)
+    guard (2.16.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
       lumberjack (>= 1.0.12, < 2.0)
@@ -172,7 +169,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
-    libv8 (3.16.14.19)
+    libv8 (3.16.14.19-x86_64-linux)
     listen (3.2.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -400,7 +397,6 @@ DEPENDENCIES
   activemodel-serializers-xml
   acts-as-taggable-on (>= 3.4.3)
   acts_as_commentable
-  acts_as_fu
   acts_as_list
   bootsnap
   brakeman
@@ -464,6 +460,7 @@ DEPENDENCIES
   selenium-webdriver
   simple_form
   sprockets-rails (>= 3.0.0)
+  sqlite3 (~> 1.3.13)
   therubyracer
   thor
   timecop

--- a/spec/lib/comment_extensions_spec.rb
+++ b/spec/lib/comment_extensions_spec.rb
@@ -11,14 +11,20 @@ describe FatFreeCRM::CommentExtensions do
   describe "add_comment_by_user" do
     let(:user) { create(:user) }
 
-    before :each do
-      build_model(:commentable_entity) do
-        string :subscribed_users
-        serialize :subscribed_users, Set
+    before do
+      ActiveRecord::Base.connection.create_table(:commentable_entities) do |t|
+        t.string :subscribed_users
+      end
 
+      class CommentableEntity < ActiveRecord::Base
+        serialize :subscribed_users, Set
         acts_as_commentable
         uses_comment_extensions
       end
+    end
+
+    after do
+      ActiveRecord::Base.connection.drop_table(:commentable_entities)
     end
 
     it "should create a comment for user" do

--- a/spec/lib/permissions_spec.rb
+++ b/spec/lib/permissions_spec.rb
@@ -8,11 +8,16 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe FatFreeCRM::Permissions do
-  before :each do
-    build_model(:user_with_permission) do
-      uses_user_permissions
-      string :access
+  before do
+    ActiveRecord::Base.connection.create_table(:user_with_permissions) do |t|
+      t.string :access
     end
+    class UserWithPermission < ActiveRecord::Base
+      uses_user_permissions
+    end
+  end
+  after do
+    ActiveRecord::Base.connection.drop_table(:user_with_permissions)
   end
 
   describe "initialization" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,6 @@ require 'rspec/rails'
 require 'capybara/rails'
 require 'paper_trail/frameworks/rspec'
 
-require 'acts_as_fu'
 require 'factory_bot_rails'
 require 'ffaker'
 require 'timecop'


### PR DESCRIPTION
Fixes #845

I'm 50-50 on this one. The objective was to remove a problem with the sqlite gem being double loaded with mixed versions. acts_as_fu uses it for in memory DB work to make a 'fake' active record model.

This way, it's DB agnostic. Or... it should be.

I feel like this warrants some more thinking around what the affected specs are actually testing.