### PR TITLE
Fix for Multiword Tags

### DIFF
--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -209,7 +209,6 @@ class EntitiesController < ApplicationController
         end
       end
     end
-    puts [query.join(" "), tags.join(", ")]
     [query.join(" "), tags.join(", ")]
   end
 

--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -197,7 +197,6 @@ class EntitiesController < ApplicationController
 
     query = []
     tags = []
-    
     if search_string.start_with?("#") && search_string.end_with?("#")
       tags << search_string[1..-2]
     else

--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -197,13 +197,19 @@ class EntitiesController < ApplicationController
 
     query = []
     tags = []
-    search_string.strip.split(/\s+/).each do |token|
-      if token.starts_with?("#")
-        tags << token[1..-1]
-      else
-        query << token
+    
+    if search_string.start_with?("#") && search_string.end_with?("#")
+      tags << search_string[1..-2]
+    else
+      search_string.strip.split(/\s+/).each do |token|
+        if token.starts_with?("#")
+          tags << token[1..-1]
+        else
+          query << token
+        end
       end
     end
+    puts [query.join(" "), tags.join(", ")]
     [query.join(" "), tags.join(", ")]
   end
 

--- a/spec/controllers/entities_controller_spec.rb
+++ b/spec/controllers/entities_controller_spec.rb
@@ -19,6 +19,11 @@ describe EntitiesController do
       expect(controller.send(:parse_query_and_tags, str)).to eq(['', 'test'])
     end
 
+    it 'should parse #multiword tags' do
+      str = "#multiword tag#"
+      expect(controller.send(:parse_query_and_tags, str)).to eq(['', 'multiword tag'])
+    end
+
     it "should parse no tags" do
       str = "test query"
       expect(controller.send(:parse_query_and_tags, str)).to eq(['test query', ''])


### PR DESCRIPTION
Allow support to search for a multiword tag by surrounding the tag with # #

![image](https://user-images.githubusercontent.com/38589044/111877348-5977be80-8979-11eb-9450-795811d5295a.png)

![image](https://user-images.githubusercontent.com/38589044/111877358-65fc1700-8979-11eb-85b5-3357ac23b29c.png)


