### PR TITLE
Lighter borders

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -438,7 +438,7 @@ $sidebar_width: 210px;
 .list {
   padding: 8px 0px 7px 0px;
   li {
-    border-bottom: 1px silver dotted;
+    border-bottom: 1px #eee dotted;
     color: #3f3f3f;
     font-size: 12px;
     list-style: none;
@@ -490,7 +490,7 @@ $sidebar_width: 210px;
     font-size: 13px;
     font-weight: bold; }
   li {
-    border-bottom: 1px silver dotted;
+    border-bottom: 1px #eee dotted;
     font-size: 12px;
     list-style: none;
     padding: 2px 0px 3px 0px;
@@ -717,7 +717,7 @@ table.asset_attributes {
   width: 100%;
   border-spacing: 4px;
   td, th {
-    border-bottom: 1px dotted silver;
+    border-bottom: 1px dotted #eee;
     vertical-align: top;
     text-align: left;
   }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -10,7 +10,7 @@ $sidebar_width: 210px;
 // Common page elements.
 //------------------------------------------------------------------------------
 .title {
-  border-bottom: 1px gray solid;
+  border-bottom: 1px #eee solid;
   color: $color_title;
   font: {
     size: 17px;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -466,7 +466,7 @@ $sidebar_width: 210px;
   -webkit-box-shadow: 2px 2px 8px #bbbbbb, -2px 0px 8px #bbbbbb;
 
   .caption {
-    border-bottom: 1px grey solid;
+    border-bottom: 1px #eee solid;
     color: navy;
     font: {
       size: 12px;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -490,7 +490,6 @@ $sidebar_width: 210px;
     font-size: 13px;
     font-weight: bold; }
   li {
-    border-bottom: 1px #eee dotted;
     font-size: 12px;
     list-style: none;
     padding: 2px 0px 3px 0px;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -35,7 +35,7 @@ $sidebar_width: 210px;
 }
 
 .subtitle {
-  border-bottom: 1px silver solid;
+  border-bottom: 1px #eee solid;
   color: #2f2f2f;
   font: {
     size: 14px;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -408,19 +408,15 @@ $sidebar_width: 210px;
 .log {
   padding: 8px 0px 0px 0px;
   h3 {
-    border-bottom: 1px #2f2f2f dotted;
     color: #2f2f2f;
     margin: 0px 0px 4px 0px;
     padding: 2px 0px 2px 86px;
     &.overdue {
-      color: crimson;
-      border-bottom: 1px crimson dotted; }
+      color: crimson; }
     &.due_asap {
-      color: darkred;
-      border-bottom: 1px darkred dotted; }
+      color: darkred; }
     &.due_today {
-      color: darkgreen;
-      border-bottom: 1px darkgreen dotted; } }
+      color: darkgreen; } }
   li {
     color: #3f3f3f;
     font-size: 12px;

--- a/app/views/accounts/_sidebar_index.html.haml
+++ b/app/views/accounts/_sidebar_index.html.haml
@@ -1,13 +1,13 @@
 .filters#filters
   .caption= t :account_categories
   - Setting.account_category.each do |key|
-    .check_box{style: "border-bottom: 1px silver dotted;"}
+    .check_box
       %div{style: "float:right;"}
         = @account_category_total[key]
       = account_category_checkbox(key, @account_category_total[key])
       = label_tag(key, t(key))
 
-  .check_box{style: "border-bottom: 1px silver dotted;"}
+  .check_box
     %div{style: "float:right;"}
       = @account_category_total[:other]
     = account_category_checkbox("other", @account_category_total[:other])

--- a/app/views/campaigns/_sidebar_index.html.haml
+++ b/app/views/campaigns/_sidebar_index.html.haml
@@ -1,13 +1,13 @@
 .filters#filters
   .caption= t :campaign_statuses
   - Setting.campaign_status.each do |key|
-    .check_box{style: "border-bottom: 1px silver dotted;"}
+    .check_box
       %div{style: "float:right;"}
         = @campaign_status_total[key]
       = campaign_status_checkbox(key, @campaign_status_total[key])
       = label_tag(key, t(key))
 
-  .check_box{style: "border-bottom: 1px silver dotted;"}
+  .check_box
     %div{style: "float:right;"}
       = @campaign_status_total[:other]
     = campaign_status_checkbox("other", @campaign_status_total[:other])

--- a/app/views/leads/_sidebar_index.html.haml
+++ b/app/views/leads/_sidebar_index.html.haml
@@ -1,13 +1,13 @@
 .filters#filters
   .caption= t :lead_statuses
   - Setting.lead_status.each do |key|
-    .check_box{style: "border-bottom: 1px silver dotted;"}
+    .check_box
       %div{style: "float:right;"}
         = @lead_status_total[key]
       = lead_status_checkbox(key, @lead_status_total[key])
       = label_tag(key, t(key))
 
-  .check_box{style: "border-bottom: 1px silver dotted;"}
+  .check_box
     %div{style: "float:right;"}
       = @lead_status_total[:other]
     = lead_status_checkbox("other", @lead_status_total[:other])

--- a/app/views/opportunities/_sidebar_index.html.haml
+++ b/app/views/opportunities/_sidebar_index.html.haml
@@ -1,13 +1,13 @@
 .filters#filters
   .caption= t :opportunity_stages
   - @stage.each do |value, key|
-    .check_box{style: "border-bottom: 1px silver dotted;"}
+    .check_box
       %div{style: "float:right;"}
         = @opportunity_stage_total[key]
       = opportunity_stage_checkbox(key, @opportunity_stage_total[key])
       = label_tag(key, value)
 
-  .check_box{style: "border-bottom: 1px silver dotted;"}
+  .check_box
     %div{style: "float:right;"}
       = @opportunity_stage_total[:other]
     = opportunity_stage_checkbox("other", @opportunity_stage_total[:other])

--- a/app/views/tasks/_sidebar_index.html.haml
+++ b/app/views/tasks/_sidebar_index.html.haml
@@ -2,13 +2,13 @@
   = render "selector"
   - if @view == "pending" || @view == "assigned"
     - Setting.unroll(:task_bucket).each do |value, key|
-      .check_box{style: "border-bottom: 1px silver dotted;"}
+      .check_box
         %div{style: "float:right;"}
           = @task_total[key]
         = task_filter_checkbox(@view, key, @task_total[key]) + " " + t(value)
   - else # @view == "completed"
     - Setting.unroll(:task_completed).each do |value, key|
-      .check_box{style: "border-bottom: 1px silver dotted;"}
+      .check_box
         %div{style: "float:right;"}
           = @task_total[key]
         = task_filter_checkbox(@view, key, @task_total[key]) + " " + t(value)


### PR DESCRIPTION
Part of #695 #906
This reduces a large number dotted lines, underlines, titles, etc; without changing the primary colours.

It does not remove all of the lines, but makes them more faint, allowing the actual content to appear more pominent, and relying on whitespace/positioning to help visually group; rather than an explicit strong border.


Before:
![image](https://user-images.githubusercontent.com/365751/117401435-bc321300-af43-11eb-85dd-a171a71f9f22.png)

After:
![image](https://user-images.githubusercontent.com/365751/117401619-1206bb00-af44-11eb-9725-cadcae6dfc29.png)


Later, other color scheme improvements or use of CSS frameworks can be applied