### PR TITLE
Change font to be similar to Bootstrap

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -26,7 +26,7 @@ html, body {
 body, ol, ul, li, dt, tt, label, input, select, textarea {
   font: {
     size: 12px;
-    family: "Lucida Grande", Geneva, Arial, Helvetica, sans-serif; }; }
+    family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol" }; }
 
 body, h1, h2, h3, h4, h5, h6, ol, ul, li {
   margin: 0px;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/365751/117416567-a844dc00-af58-11eb-997d-88470b226e73.png)

After:
![image](https://user-images.githubusercontent.com/365751/117416473-92371b80-af58-11eb-9ca1-13b870041412.png)

Makes some of the triangle symbols for expanding/collapsing sections we use look a bit funny, however we can shift those to font awesome or some other interaction approach.

Part of #906 and #695