### PR TITLE
Fixed issue with ActiveStorage missing storage.yml in production mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,5 @@
-config/*.yml
-config/deploy.rb
-!config/settings.default.yml
-!config/database.mysql.mac.yml
-!config/database.mysql.yml
-!config/database.postgres.yml
-!config/database.postgres.docker.yml
-!config/database.sqlite.yml
-!config/settings.default.yml
-
 .rspec
+config/database.yml
 spec/reports
 spec/internal/public/avatars
 spec/internal/public/assets

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,34 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+# Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
+# amazon:
+#   service: S3
+#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+#   region: us-east-1
+#   bucket: your_own_bucket
+
+# Remember not to checkin your GCS keyfile to a repository
+# google:
+#   service: GCS
+#   project: your_project
+#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
+#   bucket: your_own_bucket
+
+# Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
+# microsoft:
+#   service: AzureStorage
+#   storage_account_name: your_account_name
+#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
+#   container: your_container_name
+
+# mirror:
+#   service: Mirror
+#   primary: local
+#   mirrors: [ amazon, google, microsoft ]


### PR DESCRIPTION
Addresses issue #1016 

Before fix is applied there is an error when starting FFCRM in production mode.

After fix (adding a standard Rails storage.yml file), production mode works.