### PR TITLE
Fixes #1120 error raised when running rake db:create db:migrate the first time

### DIFF
--- a/lib/fat_free_crm/fields.rb
+++ b/lib/fat_free_crm/fields.rb
@@ -24,12 +24,10 @@ module FatFreeCRM
 
     module SingletonMethods
       def field_groups
-        begin
-          # catches cases where this code runs before database has been created or migrated
-          FieldGroup.where(klass_name: name).order(:position)
-        rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
-          []
-        end
+        # catches cases where this code runs before database has been created or migrated
+        FieldGroup.where(klass_name: name).order(:position)
+      rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
+        []
       end
 
       def fields

--- a/lib/fat_free_crm/fields.rb
+++ b/lib/fat_free_crm/fields.rb
@@ -24,9 +24,10 @@ module FatFreeCRM
 
     module SingletonMethods
       def field_groups
-        if (ActiveRecord::Base.connection.data_source_exists?('field_groups') rescue false)
+        begin
+          # catches cases where this code runs before database has been created or migrated
           FieldGroup.where(klass_name: name).order(:position)
-        else
+        rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
           []
         end
       end

--- a/lib/fat_free_crm/fields.rb
+++ b/lib/fat_free_crm/fields.rb
@@ -24,7 +24,7 @@ module FatFreeCRM
 
     module SingletonMethods
       def field_groups
-        if ActiveRecord::Base.connection.data_source_exists? 'field_groups'
+        if (ActiveRecord::Base.connection.data_source_exists?('field_groups') rescue false)
           FieldGroup.where(klass_name: name).order(:position)
         else
           []

--- a/spec/lib/fields_spec.rb
+++ b/spec/lib/fields_spec.rb
@@ -37,16 +37,20 @@ describe 'FatFreeCRM::Fields' do
   end
 
   describe "field_groups" do
-    it "should call FieldGroup" do
-      expect(ActiveRecord::Base.connection).to receive(:data_source_exists?).with('field_groups').and_return(true)
+    it "should call FieldGroup.where" do
       dummy_scope = double
       expect(dummy_scope).to receive(:order).with(:position)
       expect(FieldGroup).to receive(:where).and_return(dummy_scope)
       Foo.new.field_groups
     end
 
-    it "should not call FieldGroup if table doesn't exist (migrations not yet run)" do
-      expect(ActiveRecord::Base.connection).to receive(:data_source_exists?).with('field_groups').and_return(false)
+    it "should return [] if database doesn't exist" do
+      expect(FieldGroup).to receive(:where).and_raise(ActiveRecord::NoDatabaseError)
+      expect(Foo.new.field_groups).to eq([])
+    end
+
+    it "should return [] if FieldGroup table doesn't exist" do
+      expect(FieldGroup).to receive(:where).and_raise(ActiveRecord::StatementInvalid)
       expect(Foo.new.field_groups).to eq([])
     end
   end


### PR DESCRIPTION
This patch fixes the case where field serialization trys to run before the database has been created or migrated.

`ActiveRecord::Base.connection.data_source_exists?('field_groups')` is raising an error when the database doesn't exist. This code catches the error and returns an empty list as there is nothing to do. When the application loads and the `field_groups` table exists, the code can get to work and look for any check_box fields to serialize.

I've found it hard to write a failing test for this case as it requires not having a properly set up database.