### PR TITLE
Update gemspec to match Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,7 +510,7 @@ DEPENDENCIES
   rails_12factor
   rails_autolink
   rainbow
-  ransack (>= 1.6.2)
+  ransack (< 4)
   ransack_ui
   rb-fchange
   rb-fsevent

--- a/fat_free_crm.gemspec
+++ b/fat_free_crm.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'paper_trail',         '~> 15.0.0'
   gem.add_dependency 'devise',              '~> 4.6'
   gem.add_dependency 'devise-encryptable',  '~> 0.2.0'
-  gem.add_dependency 'acts_as_commentable', '~> 6.0.0'
+  gem.add_dependency 'acts_as_commentable', '>= 6.1'
   gem.add_dependency 'acts-as-taggable-on', '>= 3.4.3'
   gem.add_dependency 'dynamic_form'
   gem.add_dependency 'haml'
@@ -50,6 +50,7 @@ Gem::Specification.new do |gem|
 
   # FatFreeCRM has released it's own versions of the following gems:
   #-----------------------------------------------------------------
-  gem.add_dependency 'ransack', '>= 1.6.2'
+  gem.add_dependency 'ransack', '< 4'
+  gem.add_dependency 'ransack_ui'
   gem.add_dependency 'email_reply_parser_ffcrm'
 end


### PR DESCRIPTION
This brings parity when fat_free_crm is loaded as an engine, via a gem.

Fixes following bundler error when including fat_free_crm as a gem

```
Fetching https://github.com/fatfreecrm/acts_as_commentable.git
Fetching https://github.com/CloCkWeRX/responds_to_parent.git
Fetching https://github.com/fatfreecrm/fat_free_crm.git
Fetching gem metadata from http://rubygems.org/...........
Resolving dependencies...
Could not find compatible versions

Because acts_as_commentable >= 6.0.0, < 6.1.A could not be found in https://github.com/fatfreecrm/acts_as_commentable.git (at rails-61@e695ef5)
  and every version of fat_free_crm depends on acts_as_commentable ~> 6.0.0,
  fat_free_crm cannot be used.
So, because Gemfile depends on fat_free_crm >= 0,
  version solving has failed.
```