### PR TITLE
Added controller hooks to make it easier to hook plugins into the FFCRM bootup sequence

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -268,4 +268,6 @@ class ApplicationController < ActionController::Base
       raise "Unknown resource"
     end
   end
+
+  ActiveSupport.run_load_hooks(:fat_free_crm_application_controller, self)
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -99,4 +99,6 @@ class CommentsController < ApplicationController
   def extract_commentable_name(params)
     params.keys.detect { |x| x =~ /_id$/ }.try(:sub, /_id$/, '')
   end
+
+  ActiveSupport.run_load_hooks(:fat_free_crm_comments_controller, self)
 end

--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -15,4 +15,6 @@ class EmailsController < ApplicationController
     @email.destroy
     respond_with(@email)
   end
+  
+  ActiveSupport.run_load_hooks(:fat_free_crm_emails_controller, self)
 end

--- a/app/controllers/entities/accounts_controller.rb
+++ b/app/controllers/entities/accounts_controller.rb
@@ -160,4 +160,6 @@ class AccountsController < EntitiesController
     @account_category_total[:all] = Account.my(current_user).count
     @account_category_total[:other] = @account_category_total[:all] - categorized
   end
+
+  ActiveSupport.run_load_hooks(:fat_free_crm_accounts_controller, self)
 end

--- a/app/controllers/entities/campaigns_controller.rb
+++ b/app/controllers/entities/campaigns_controller.rb
@@ -204,4 +204,6 @@ class CampaignsController < EntitiesController
     end
     @campaign_status_total[:other] += @campaign_status_total[:all]
   end
+
+  ActiveSupport.run_load_hooks(:fat_free_crm_campaigns_controller, self)
 end

--- a/app/controllers/entities/contacts_controller.rb
+++ b/app/controllers/entities/contacts_controller.rb
@@ -164,4 +164,6 @@ class ContactsController < EntitiesController
       redirect_to contacts_path
     end
   end
+  
+  ActiveSupport.run_load_hooks(:fat_free_crm_contacts_controller, self)
 end

--- a/app/controllers/entities/leads_controller.rb
+++ b/app/controllers/entities/leads_controller.rb
@@ -268,4 +268,6 @@ class LeadsController < EntitiesController
       get_data_for_sidebar(:campaign)
     end
   end
+
+  ActiveSupport.run_load_hooks(:fat_free_crm_leads_controller, self)
 end

--- a/app/controllers/entities/opportunities_controller.rb
+++ b/app/controllers/entities/opportunities_controller.rb
@@ -227,4 +227,6 @@ class OpportunitiesController < EntitiesController
     current_user.pref[:opportunities_sort_by]  = Opportunity.sort_by_map[params[:sort_by]] if params[:sort_by]
     session[:opportunities_filter] = params[:stage] if params[:stage]
   end
+
+  ActiveSupport.run_load_hooks(:fat_free_crm_opportunities_controller, self)
 end

--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -245,4 +245,6 @@ class EntitiesController < ApplicationController
       Account.new(user: user)
     end
   end
+
+  ActiveSupport.run_load_hooks(:fat_free_crm_entities_controller, self)
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -165,4 +165,6 @@ class HomeController < ApplicationController
       %w[zero one two].index(words.first).send(words.last) if %w[one two].include?(words.first) && %w[hour day days week weeks month].include?(words.last)
     end
   end
+
+  ActiveSupport.run_load_hooks(:fat_free_crm_home_controller, self)
 end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -39,4 +39,6 @@ class ListsController < ApplicationController
       :user_id
     )
   end
+
+  ActiveSupport.run_load_hooks(:fat_free_crm_lists_controller, self)
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -224,4 +224,6 @@ class TasksController < ApplicationController
     views = Task::ALLOWED_VIEWS
     views.include?(view) ? view : views.first
   end
+
+  ActiveSupport.run_load_hooks(:fat_free_crm_tasks_controller, self)
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -143,4 +143,6 @@ class UsersController < ApplicationController
       .permit(:image)
       .merge(entity: @user, user_id: @user.id)
   end
+
+  ActiveSupport.run_load_hooks(:fat_free_crm_users_controller, self)
 end


### PR DESCRIPTION
When Fat Free CRM is run as an engine, other plugins need to be able to attach themselves to various parts of the boot up sequence to add or modify features. These new hooks enable code to target specific controllers in FFCRM (similar to the lazy load hooks that are already in place for models).

Once merged, I'll update https://github.com/fatfreecrm/fat_free_crm/wiki/Lazy-Load-Hooks