### PR TITLE
Fix db/demo/field_groups.yml to generate valid entries

### DIFF
--- a/db/demo/field_groups.yml
+++ b/db/demo/field_groups.yml
@@ -10,5 +10,6 @@ field_group_<%= i %>:
   id          : <%= i %>
   klass_name  : <%= klasses[i-1] %>
   name        : "Extra"
-  position    : 1
+  position    : 1,
+  label       : "Extra"
 <% end %>


### PR DESCRIPTION
`label` is a requried field_group attribute but wasn't being properly generated in the demo data.