### PR TITLE
is_haml? is no longer available. Use ActionView::Base instead

### DIFF
--- a/lib/fat_free_crm/callback.rb
+++ b/lib/fat_free_crm/callback.rb
@@ -108,10 +108,9 @@ module FatFreeCRM
     #--------------------------------------------------------------------------
     module Helper
       def hook(method, caller, context = {}, &block)
-        is_view_hook = caller.is_haml?
 
-        # If a block was given, hooks are able to replace, append or prepend view content.
-        if is_view_hook
+        # In a view template context, hooks are able to replace, append or prepend content.
+        if caller.is_a?(ActionView::Base)
           hooks = FatFreeCRM::Callback.view_hook(method, caller, context)
           # Add content to the view in the following order:
           # -- before


### PR DESCRIPTION
Recent versions of haml gem no longer have the `is_haml?` method so taking a different approach to indentifying callback context.