### PR TITLE
Schedule emails to deliver asynchronously

### DIFF
--- a/app/models/observers/entity_observer.rb
+++ b/app/models/observers/entity_observer.rb
@@ -19,7 +19,7 @@ class EntityObserver < ActiveRecord::Observer
   private
 
   def send_notification_to_assignee(item)
-    UserMailer.assigned_entity_notification(item, current_user).deliver_now if item.assignee.present? && current_user.present? && can_send_email?
+    UserMailer.assigned_entity_notification(item, current_user).deliver_later if item.assignee.present? && current_user.present? && can_send_email?
   end
 
   # Need to have a host set before email can be sent

--- a/app/models/polymorphic/comment.rb
+++ b/app/models/polymorphic/comment.rb
@@ -54,7 +54,7 @@ class Comment < ActiveRecord::Base
   def notify_subscribers
     commentable.subscribed_users.reject { |user_id| user_id == user.id }.each do |subscriber_id|
       if subscriber = User.find_by_id(subscriber_id)
-        SubscriptionMailer.comment_notification(subscriber, self).deliver_now
+        SubscriptionMailer.comment_notification(subscriber, self).deliver_later
       end
     end
   end

--- a/lib/fat_free_crm/mail_processor/dropbox.rb
+++ b/lib/fat_free_crm/mail_processor/dropbox.rb
@@ -258,7 +258,7 @@ module FatFreeCRM
       def notify(email, mediator_links)
         DropboxMailer.create_dropbox_notification(
           @sender, @settings[:address], email, mediator_links
-        ).deliver_now
+        ).deliver_later
       end
     end
   end

--- a/spec/models/observers/entity_observer_spec.rb
+++ b/spec/models/observers/entity_observer_spec.rb
@@ -18,7 +18,7 @@ describe EntityObserver do
       let(:assignee) { create(:user) }
       let(:assigner) { create(:user) }
       let!(:entity)  { build(entity_type, user: assigner, assignee: assignee) }
-      let(:mail) { double('mail', deliver_now: true) }
+      let(:mail) { double('mail', deliver_later: true) }
 
       after :each do
         entity.save
@@ -48,7 +48,7 @@ describe EntityObserver do
       let(:assignee) { create(:user) }
       let(:assigner) { create(:user) }
       let!(:entity)  { create(entity_type, user: create(:user)) }
-      let(:mail) { double('mail', deliver_now: true) }
+      let(:mail) { double('mail', deliver_later: true) }
 
       it "notifies the new owner if the entity is re-assigned" do
         expect(UserMailer).to receive(:assigned_entity_notification).with(entity, assigner).and_return(mail)


### PR DESCRIPTION
Using `deliver_later` rather than `deliver_now` will send emails in a separate async thread (default in development).

This enables better integration with Rails ActiveJob configurations which may be altered to use a more robust queuing solution (e.g. delayed_job / sidekiq) in production setups.

It also removes email generation/sending from the main request thread and hence speeds up response times.