### PR TITLE
Replace usage of request.fullpath / request.referrer

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,13 +126,12 @@ module ApplicationHelper
 
   #----------------------------------------------------------------------------
   def link_to_discard(object)
-    current_url = (request.xhr? ? request.referer : request.fullpath)
-    parent, parent_id = current_url.scan(%r{/(\w+)/(\d+)}).flatten
-
-    link_to(t(:discard),
-            url_for(controller: parent, action: :discard, id: parent_id, attachment: object.class.name, attachment_id: object.id),
-            method:  :post,
-            remote:  true)
+    if entity.present?
+      link_to(t(:discard),
+        url_for(controller: entity.class.to_s.tableize, action: 'discard', id: entity.id, attachment: object.class.name, attachment_id: object.id),
+        method:  :post,
+        remote:  true)
+    end
   end
 
   #----------------------------------------------------------------------------

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -35,13 +35,18 @@ describe ApplicationHelper do
     end
   end
 
-  it "link_to_discard" do
-    lead = create(:lead)
-    allow(controller.request).to receive(:fullpath).and_return("http://www.example.com/leads/#{lead.id}")
-
-    link = helper.link_to_discard(lead)
-    expect(link).to match(%r{leads/#{lead.id}/discard})
-    expect(link).to match(/attachment=Lead&amp;attachment_id=#{lead.id}/)
+  describe "link_to_discard" do
+    let(:contact) { create(:contact) }
+    let(:opportunity) { create(:opportunity) }
+    before do
+      contact.opportunities << opportunity
+      allow(helper).to receive(:entity).and_return(contact)
+    end
+    it do
+      link = helper.link_to_discard(opportunity)
+      expect(link).to match(%r{contacts/#{contact.id}/discard})
+      expect(link).to match(/attachment=Opportunity&amp;attachment_id=#{opportunity.id}/)
+    end
   end
 
   describe "shown_on_landing_page?" do


### PR DESCRIPTION
Seems strange that we are using request.referrer / request.fullpath to determine what the related object is. Using `entity` from the controller seems like a better way to locate the expected object. Also no longer breaks in rare cases where `entity` doesn't exist.

This should be a backwards compatible change.