### PR TITLE
Fix custom field error

### DIFF
--- a/app/models/fields/custom_field.rb
+++ b/app/models/fields/custom_field.rb
@@ -142,7 +142,7 @@ class CustomField < Field
   #------------------------------------------------------------------------------
   def update_column
     if errors.empty? && db_transition_safety(as_was) == :safe
-      klass.connection.change_column(table_name, name, column_type, column_options)
+      klass.connection.change_column(table_name, name, column_type, **column_options)
       klass.reset_column_information
       klass.serialize_custom_fields!
     end

--- a/app/models/fields/custom_field.rb
+++ b/app/models/fields/custom_field.rb
@@ -124,7 +124,7 @@ class CustomField < Field
   #------------------------------------------------------------------------------
   def add_column
     self.name = generate_column_name if name.blank?
-    klass.connection.add_column(table_name, name, column_type, column_options)
+    klass.connection.add_column(table_name, name, column_type, **column_options)
     klass.reset_column_information
     klass.serialize_custom_fields!
   end

--- a/spec/models/fields/custom_field_spec.rb
+++ b/spec/models/fields/custom_field_spec.rb
@@ -31,12 +31,25 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 describe CustomField do
   it "should add a column to the database" do
     expect(CustomField.connection).to receive(:add_column)
-      .with("contacts", "cf_test_field", 'string', {})
+      .with("contacts", "cf_test_field", 'string')
     expect(Contact).to receive(:reset_column_information)
     expect(Contact).to receive(:serialize_custom_fields!)
 
     create(:custom_field,
            as: "string",
+           name: "cf_test_field",
+           label: "Test Field",
+           field_group: create(:field_group, klass_name: "Contact"))
+  end
+
+  it "should add a column to the database and include column_options" do
+    expect(CustomField.connection).to receive(:add_column)
+      .with("contacts", "cf_test_field", 'decimal', {"precision" => 15, "scale" => 2})
+    expect(Contact).to receive(:reset_column_information)
+    expect(Contact).to receive(:serialize_custom_fields!)
+
+    create(:custom_field,
+           as: "decimal",
            name: "cf_test_field",
            label: "Test Field",
            field_group: create(:field_group, klass_name: "Contact"))
@@ -75,9 +88,9 @@ describe CustomField do
 
   it "should change a column's type for safe transitions" do
     expect(CustomField.connection).to receive(:add_column)
-      .with("contacts", "cf_test_field", 'string', {})
+      .with("contacts", "cf_test_field", 'string')
     expect(CustomField.connection).to receive(:change_column)
-      .with("contacts", "cf_test_field", 'text', {})
+      .with("contacts", "cf_test_field", 'text')
     expect(Contact).to receive(:reset_column_information).twice
     expect(Contact).to receive(:serialize_custom_fields!).twice
 


### PR DESCRIPTION
With a base installation of Fat Free CRM, creating a Custom Field generates the following error:

```
ArgumentError (wrong number of arguments (given 4, expected 3)):

app/models/fields/custom_field.rb:127:in `add_column'
app/controllers/admin/fields_controller.rb:50:in `create'
```

This PR fixes that by bringing the `add_column` usage into line with recent changes in Rails.