### PR TITLE
Handle edge case where application is unable to run tasks/migrations

### DIFF
--- a/config/initializers/custom_field_ransack_translations.rb
+++ b/config/initializers/custom_field_ransack_translations.rb
@@ -18,6 +18,7 @@ if Setting.database_and_table_exists?
         translations[:ransack][:attributes][model_key][custom_field.name] = custom_field.label
       end
     end
+    rescue ActiveRecord::StatementInvalid, PG::UndefinedTable # can happen if a migration fails and DB is not correctly setup.
 
     I18n.backend.store_translations(Setting.locale.to_sym, translations)
   end


### PR DESCRIPTION
I'm in two minds about this PR so open to alternative views here!

The case I'm addressing is that if DB migrations fail at a particular point (during CustomField creation), then we have a situation where the rails app can't properly initialize because we have code in the custom field initializer that expects certain tables and models to exist.

If the rails app is unable to initialize, we can't re-run migrations to fix the problem and therefore have a catch-22 situation.

Since the code in the custom field initializer only really needs to provide a list to ransack for model names and translations, I think it's ok for it to fail and proceed gracefully. This will enable rake to be run to fix problems and once migrations have run properly, the ransack translation code will run properly at next boot up.

As I mentioned, open to alternative implementations.