### PR TITLE
Whitelist HashWithIndifferentAccess for field serialization

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -78,6 +78,7 @@ module FatFreeCRM
     config.active_record.use_yaml_unsafe_load = false
     config.active_record.yaml_column_permitted_classes = [
       ::ActiveRecord::Type::Time::Value,
+      ::ActiveSupport::HashWithIndifferentAccess, # for Field#settings serialization see app/models/fields/field.rb
       ::ActiveSupport::TimeWithZone,
       ::ActiveSupport::TimeZone,
       ::BigDecimal,


### PR DESCRIPTION
We currently store field configuration in the table using the YAML coder and HashWithIndifferentAccess class. 

This PR ensures HashWithIndifferentAccess is whitelisted in the YAML coder.

A future PR could migrate away from HashWithIndifferentAccess and use Ruby's standard Hash class instead. This would require a migration script to ensure all Hash keys were converted and thoroughly consistent throughout the all. i.e all to string or all to symbol.