### PR TITLE
Enable FFCRM to export assets when run as an engine

### DIFF
--- a/app/assets/config/fat_free_crm.js
+++ b/app/assets/config/fat_free_crm.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,1 @@
-//= link_tree ../images
-//= link_directory ../javascripts .js
-//= link_directory ../stylesheets .css
+//= link fat_free_crm


### PR DESCRIPTION
When FFCRM is mounted as an engine inside another Rails app, the css, js, images are not accessible. This PR fixes that by creating `fat_free_crm.js` which can be referenced from the manifest of the parent application.

For example, given a parent app that includes `fat_free_crm` as a gem, the following app/assets/config/manifest.js will load the FFCRM assets as well as the parent app assets:

```
//= link fat_free_crm

//= link_tree ../images
//= link_directory ../javascripts .js
//= link_directory ../stylesheets .css
```

If FFCRM is run in standalone mode (no parent Rails app) the normal `app/assets/config/manifest.js` is used for asset compilation. This is now links directly to fat_free_crm.js in order to avoid having to maintain two separate files.

I've tested this PR with the following use cases:

* FFCRM in standalone development mode
* FFCRM in standalone production mode (rails assets:precompile)
* FFCRM in engine development mode
* FFCRM in engine production mode (rails assets:precompile)