### PR TITLE
Safer setting check

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -58,9 +58,9 @@ class Setting < ActiveRecord::Base
       return cache[name] if cache.key?(name)
 
       # Check database
-      if database_and_table_exists? && setting = find_by_name(name.to_s) && !setting.value.nil?
+      if database_and_table_exists? && (setting = find_by_name(name.to_s))&.value.present?
         return cache[name] = setting.value
-        end
+      end
       # Check YAML settings
       return cache[name] = yaml_settings[name] if yaml_settings.key?(name)
     end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -54,6 +54,11 @@ describe Setting do
     expect(Setting.hello).to eq(false)
   end
 
+  it "should return nil if setting is missing and no default value is provided by YAML" do
+    expect(Setting[:missing]).to eq(nil)
+    expect(Setting.missing).to eq(nil)
+  end
+
   describe "#dig" do
     it "should dig into nested hashes" do
       Setting[:hello] = { foo: { bar: 3 } }


### PR DESCRIPTION
Fix for case when `setting` is nil (raises NoMethodError: undefined method `value' for nil:NilClass). Replaces "double negative" check with safe operator check.

