### PR TITLE
Fix arrow rendering

### DIFF
--- a/app/assets/javascripts/crm.js.coffee
+++ b/app/assets/javascripts/crm.js.coffee
@@ -9,8 +9,8 @@
     @[0].toUpperCase() + @.substring(1)
 
   window.crm =
-    EXPANDED: "&#9660;"
-    COLLAPSED: "&#9658;"
+    EXPANDED: "&#9661;"
+    COLLAPSED: "&#9655;"
     searchRequest: null
     autocompleter: null
     base_url: ""

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,7 +36,7 @@ module ApplicationHelper
   end
 
   def subtitle_link(id, text, hidden)
-    link_to("<small>#{hidden ? '&#9658;' : '&#9660;'}</small> #{sanitize text}".html_safe,
+    link_to("<small>#{hidden ? '&#9655;' : '&#9661;'}</small> #{sanitize text}".html_safe,
             url_for(controller: :home, action: :toggle, id: id),
             remote: true,
             onclick: "crm.flip_subtitle(this)")
@@ -99,7 +99,7 @@ module ApplicationHelper
 
   #----------------------------------------------------------------------------
   def arrow_for(id)
-    content_tag(:span, "&#9658;".html_safe, id: "#{id}_arrow", class: :arrow)
+    content_tag(:span, "&#9655;".html_safe, id: "#{id}_arrow", class: :arrow)
   end
 
   #----------------------------------------------------------------------------


### PR DESCRIPTION
Right-arrows don't render well (I'm on Microsoft Edge / Windows 11) See squashed arrow next to "General Information"

![image](https://github.com/fatfreecrm/fat_free_crm/assets/149198/ec419005-b87b-46cb-8c52-e2b667573150)

Having spent some time investigating, it turns out the font is rendering badly under certain circumstances...I'm not sure what they are. We can either change the base font to a cross-platform 'sans-serif' or change the arrows from solid to outline. Changing the arrows feels less invasive.

![image](https://github.com/fatfreecrm/fat_free_crm/assets/149198/304f812f-7943-4d45-8061-e2fcd9dcab8c)

Open to opinions or better fixes here.

Note: I have customised views that use the right/down arrows extensively, hence my interest. But I'm keen to implement the best solution for the wider project.