### PR TITLE
Correct font-sizes for mobile views using dl layouts.

### DIFF
--- a/app/assets/stylesheets/bootstrap-custom.scss
+++ b/app/assets/stylesheets/bootstrap-custom.scss
@@ -165,12 +165,12 @@ button.navbar-toggler:focus {
       dl {
         li {
 	  width: 23%;
-	  font-size: 2rem;
+	  font-size: 1rem;
 	  dt {
-	    font-size: inherit;
+	    font-size: 0.75rem;
           }
           tt {
-	    font-size: inherit;
+	    font-size: 0.75rem;
 	  }
 	}
       }	


### PR DESCRIPTION
Views of contacts / opportunities / accounts had a layout bug when viewed in mobile browsers...

![image](https://github.com/fatfreecrm/fat_free_crm/assets/149198/f0b771c8-3f99-4568-a9d1-99ff7bdc9870)

This PR reduces the font sizes down to more manageable levels.

![image](https://github.com/fatfreecrm/fat_free_crm/assets/149198/edf833ed-e116-4510-89eb-4158cb21db01)
