### PR TITLE
Removed border around 'remember me' and used primary button colour for Login button

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -784,3 +784,12 @@ table.asset_attributes {
     background-color: darkgray;
   }
 }
+
+
+// Login page
+.form-group.user_remember_me {
+  border: 0px;
+  .form-check {
+    padding-left: 6px;
+  }
+}

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -23,10 +23,9 @@
       .label= t(:password)
       = f.input_field :password
 
-    %div(style="margin-left:12px")
+    .section
       = f.input :remember_me, as: :boolean, inline_label: t('remember_me')
-    %br
-    .buttonbar
-      = f.submit t(:login)
-      = t(:or)
+      = f.submit t(:login), class: 'btn btn-primary'
+
+    .section
       = link_to t(:forgot_password) + '?', new_password_path(resource_name)


### PR DESCRIPTION
The login page UI had a few too many borders...

![Screenshot 2024-02-22 125931](https://github.com/fatfreecrm/fat_free_crm/assets/149198/cd4e9f2e-b559-42f3-8828-a0de8f20932b)

Changes:
* removed the border around 'Remember me"
* removed the line above the Login button
* set Login button to primary button styling used elsewhere
* moved "Forgot password" to below the button

![Screenshot 2024-02-22 125857](https://github.com/fatfreecrm/fat_free_crm/assets/149198/6e8b37f2-2fbc-4545-b2a5-5143afbb1a2c)
