### PR TITLE
Fix layout of custom field inputs. Now consistent with other form inputs

### DIFF
--- a/app/views/fields/_group_table.html.haml
+++ b/app/views/fields/_group_table.html.haml
@@ -8,6 +8,8 @@
           - if field.as == 'check_boxes'
             - value = f.object.send(field.name)
             - checked = YAML.load(value.to_s)
-          = f.input field.name, field.input_options.merge(checked: checked)
+          .label.top
+            = "#{field.label}:"
+          = f.input_field field.name, field.input_options.merge(checked: checked)
         - if i == 0
           %td= spacer


### PR DESCRIPTION
The size of the inputs on custom fields was larger than the rest of the form. This was related to the introduction of the form-control class for bootstrap forms.

Before this fix:

![custom-field-old](https://github.com/fatfreecrm/fat_free_crm/assets/149198/5f1b2e30-2b70-4ea3-8b7e-7bc62492c342)

After this fix:

![Screenshot 2024-02-22 152032](https://github.com/fatfreecrm/fat_free_crm/assets/149198/e2b01d8c-e017-43fd-ba48-cc30352a1753)
