### PR TITLE
Fix load paths - this works for both Application and Engine mode.

### DIFF
--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -10,7 +10,7 @@
 #   ActionMailer is setup in test mode later on
 #
 unless Rails.env.test?
-  require './app/models/setting'
+  require 'setting'
 
   smtp_settings = Setting.smtp || {}
 

--- a/config/initializers/custom_field_ransack_translations.rb
+++ b/config/initializers/custom_field_ransack_translations.rb
@@ -6,7 +6,7 @@
 # See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
 # Load field names for custom fields, for Ransack search
-require './app/models/setting'
+require 'setting'
 if Setting.database_and_table_exists?
   Rails.application.config.after_initialize do
     I18n.backend.load_translations


### PR DESCRIPTION
When loading FFCRM as an engine, ```require './app/models/setting'``` doesn't load the correct file.

Changing it to ```require 'setting'``` will cause ruby to use the load paths