### PR TITLE
Fix case where entity is updated but the view doesn't refresh

### DIFF
--- a/app/views/accounts/update.js.haml
+++ b/app/views/accounts/update.js.haml
@@ -7,6 +7,7 @@
     crm.flip_form('edit_#{entity_name}');
     crm.set_title('edit_#{entity_name}', '#{j @entity.name}');
     = refresh_sidebar(:show)
+    $('#summary').html('#{ j (render partial: "#{entity_name.pluralize}/sidebar_show", entity_name => @entity) }');
   - else
     $('##{id}').replaceWith('#{ j render(partial: entity_name, collection: [ @entity ]) }');
     $('##{id}').effect("highlight", { duration:1500 });

--- a/app/views/campaigns/update.js.haml
+++ b/app/views/campaigns/update.js.haml
@@ -7,6 +7,7 @@
     crm.flip_form('edit_#{entity_name}');
     crm.set_title('edit_#{entity_name}', '#{h @entity.name}');
     = refresh_sidebar(:show)
+    $('#summary').html('#{ j (render partial: "#{entity_name.pluralize}/sidebar_show", entity_name => @entity) }');
   - else
     $('##{id}').replaceWith('#{ j render(partial: entity_name, collection: [ @entity ]) }');
     $('##{id}').effect("highlight", { duration:1500 });

--- a/app/views/contacts/update.js.haml
+++ b/app/views/contacts/update.js.haml
@@ -8,6 +8,7 @@
     crm.flip_form('edit_#{entity_name}');
     crm.set_title('edit_#{entity_name}', '#{h @entity.full_name}');
     = refresh_sidebar(:show)
+    $('#summary').html('#{ j (render partial: "#{entity_name.pluralize}/sidebar_show", entity_name => @entity) }');
   - else
     $('##{id}').replaceWith('#{ j render(partial: entity_name, collection: [ @entity ]) }');
     $('##{id}').effect("highlight", { duration:1500 });

--- a/app/views/leads/update.js.haml
+++ b/app/views/leads/update.js.haml
@@ -7,6 +7,7 @@
     crm.flip_form('edit_#{entity_name}');
     crm.set_title('edit_#{entity_name}', '#{h @entity.full_name}');
     = refresh_sidebar(:show)
+    $('#summary').html('#{ j (render partial: "#{entity_name.pluralize}/sidebar_show", entity_name => @entity) }');
   - else
     $('##{id}').replaceWith('#{ j render(partial: entity_name, collection: [ @entity ]) }');
     $('##{id}').effect("highlight", { duration:1500 });

--- a/app/views/opportunities/update.js.haml
+++ b/app/views/opportunities/update.js.haml
@@ -7,6 +7,7 @@
     crm.flip_form('edit_#{entity_name}');
     crm.set_title('edit_#{entity_name}', '#{h @entity.name}');
     = refresh_sidebar(:show)
+    $('#summary').html('#{ j (render partial: "#{entity_name.pluralize}/sidebar_show", entity_name => @entity) }');
   - else
     $('##{id}').replaceWith('#{ j render(partial: entity_name, collection: [ @entity ]) }');
     $('##{id}').effect("highlight", { duration:1500 });


### PR DESCRIPTION
When an entity (such as contact) is editted, and saved. The original view was not being refreshed with changed data. This PR fixes that behaviour.

E.g. If you edit a contact, change the assignee and press 'save', the old assignee is still displayed. This is because the view is not refreshing after update.

![image](https://github.com/fatfreecrm/fat_free_crm/assets/149198/7a00728b-38aa-4636-a60e-673683dcbb01)

Note that this occurred after entity details were moved from the sidebar (which does refresh) into the main view pane.

This solution still uses the decade-old rjs approach. Rails 7 gives us a much nicer Turbo interface for refreshing parts of the page and would bring a significant UI performance improvement. One for the Todo list.