### PR TITLE
Fixed missing select2 box on address country input

### DIFF
--- a/app/assets/javascripts/crm_select2.js.coffee
+++ b/app/assets/javascripts/crm_select2.js.coffee
@@ -15,6 +15,7 @@
         $(this).select2
           'width':'resolve'
           placeholder: $(this).attr("placeholder")
+          allowClear: true
           ajax:
             url: $(this).data("url")
             dataType: 'json'
@@ -22,16 +23,18 @@
         $(this).select2
           'width':'resolve'
           placeholder: $(this).attr("placeholder")
+          allowClear: true
 
       if $(this).prop("disabled") == true
         $(this).next('.select2-container').disable()
-        $(this).next('.select2-container').hide()    
+        $(this).next('.select2-container').hide()
 
     $(".select2_tag").not(".select2-container, .select2-offscreen").each ->
       $(this).select2
         'width':'resolve'
         placeholder: $(this).data("placeholder")
         multiple: $(this).data("multiple")
+        allowClear: true
 
   $(document).ready ->
     crm.make_select2()

--- a/app/views/shared/_address.html.haml
+++ b/app/views/shared/_address.html.haml
@@ -41,4 +41,4 @@
           = address_field(a, :zipcode, "width:80px;")
         %td= spacer
         %td
-          = a.country_select(:country, priority_countries: priority_countries, include_blank: "", :"data-placeholder" => t(:select_a_country), style: "width:150px; margin-top:6px", class: 'select2')
+          = a.country_select(:country, {priority_countries: priority_countries, include_blank: true}, {data: { placeholder: t(:select_a_country)}, class: 'select2'})

--- a/config/settings.default.yml
+++ b/config/settings.default.yml
@@ -192,7 +192,8 @@
 #------------------------------------------------------------------------------
 # Specify which countries (if any) should appear at the top of country pickers
 # priority_countries:
-#  - Burkina Faso
+#  - AU
+#  - BF
 
 # Main and Admin Tabs
 #------------------------------------------------------------------------------


### PR DESCRIPTION
The country picker for contact address was not getting picked up by the select2 js code. This PR fixes is and also enables the option to clear the input.

The settings.default.yml file is also updated to indicate that you should pass country ISO codes instead of country names to prioritise certain countries. Here Australia and Burkina Faso are prioritised.

![image](https://github.com/fatfreecrm/fat_free_crm/assets/149198/d2cfda40-b983-4f46-a02a-8ebfade74f8b)
