### PR TITLE
Fix ActionView::MissingTempateError when requesting entity views by JS

### DIFF
--- a/app/views/accounts/show.js.haml
+++ b/app/views/accounts/show.js.haml
@@ -1,5 +1,5 @@
 - entity_name = controller.controller_name.singularize.underscore #account
 - @entity = instance_variable_get("@#{entity_name}")
 
-$('#main').html('#{ j (render template: "#{entity_name.pluralize}/show.html", entity_name => @entity) }');
+$('#main').html('#{ j (render template: "#{entity_name.pluralize}/show", formats: [:html], entity_name => @entity) }');
 = raw generate_js_for_popups(@entity, :tasks, :contacts, :opportunities)

--- a/app/views/campaigns/show.js.haml
+++ b/app/views/campaigns/show.js.haml
@@ -1,5 +1,5 @@
 - entity_name = controller.controller_name.singularize.underscore #account
 - @entity = instance_variable_get("@#{entity_name}")
 
-$('#main').html('#{ j (render template: "#{entity_name.pluralize}/show.html", entity_name => @entity) }');
+$('#main').html('#{ j (render template: "#{entity_name.pluralize}/show", formats: [:html], entity_name => @entity) }');
 = raw generate_js_for_popups(@entity, :tasks, :leads, :opportunities)

--- a/app/views/contacts/show.js.haml
+++ b/app/views/contacts/show.js.haml
@@ -1,5 +1,4 @@
 - entity_name = controller.controller_name.singularize.underscore
 - @entity = instance_variable_get("@#{entity_name}")
-
-$('#main').html('#{ j (render template: "#{entity_name.pluralize}/show.html", entity_name => @entity) }');
+$('#main').html('#{ j (render template: "#{entity_name.pluralize}/show", formats: [:html], entity_name => @entity) }');
 = raw generate_js_for_popups(@entity, :tasks, :opportunities)

--- a/app/views/leads/show.js.haml
+++ b/app/views/leads/show.js.haml
@@ -1,5 +1,5 @@
 - entity_name = controller.controller_name.singularize.underscore #account
 - @entity = instance_variable_get("@#{entity_name}")
 
-$('#main').html('#{ j (render template: "#{entity_name.pluralize}/show.html", entity_name => @entity) }');
+$('#main').html('#{ j (render template: "#{entity_name.pluralize}/show", formats: [:html], entity_name => @entity) }');
 = raw generate_js_for_popups(@entity, :tasks)

--- a/app/views/opportunities/show.js.haml
+++ b/app/views/opportunities/show.js.haml
@@ -1,5 +1,5 @@
 - entity_name = controller.controller_name.singularize.underscore #account
 - @entity = instance_variable_get("@#{entity_name}")
 
-$('#main').html('#{ j (render template: "#{entity_name.pluralize}/show.html", entity_name => @entity) }');
+$('#main').html('#{ j (render template: "#{entity_name.pluralize}/show", formats: [:html], entity_name => @entity) }');
 = raw generate_js_for_popups(@entity, :tasks, :contacts)


### PR DESCRIPTION
In some cases, when fetching an entity view by JS, ActionView has a hard time finding the template to render and throws an error.

This can be fixed by extracting the format from the template name and passing it inside the `formats` parameter.

Old format: `render template: "contacts/show.html"`
New format: `render template: "contacts/show", formats: [:html]`

Useful references;
* https://github.com/mileszs/wicked_pdf/issues/1005
* https://guides.rubyonrails.org/layouts_and_rendering.html#the-formats-option