### PR TITLE
Fix validation issues

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -17,6 +17,7 @@
 //= require crm_loginout
 //= require crm_tags
 //= require crm_sortable
+//= require crm_validations
 //= require textarea_autocomplete
 //= require crm_textarea_autocomplete
 //= require crm_select2

--- a/app/assets/javascripts/crm_validations.js.coffee
+++ b/app/assets/javascripts/crm_validations.js.coffee
@@ -1,0 +1,12 @@
+#------------------------------------------------------------------------------
+(($) ->
+
+  # Ensure that any html5 required fields are unhidden when invalid
+  #----------------------------------------------------------------------------
+  $(document).on 'click', 'form.simple_form input:submit', (event) ->
+    form = this.closest('form')
+    invalidInputs = form.querySelectorAll(':invalid')
+    $(invalidInputs).each ->
+      $(this).closest('.field_group').show()
+
+) jQuery

--- a/app/assets/stylesheets/rails.scss
+++ b/app/assets/stylesheets/rails.scss
@@ -28,7 +28,7 @@
       padding: 0px; } } }
 
 .fieldWithErrors {
-  input {
+  input, select {
     border: {
       bottom: 1px solid lightpink;
       right: 1px solid lightpink; };

--- a/app/models/fields/field.rb
+++ b/app/models/fields/field.rb
@@ -74,7 +74,7 @@ class Field < ActiveRecord::Base
   def input_options
     input_html = {}
     attributes.reject do |k, v|
-      !%w[as collection disabled label placeholder minlength maxlength].include?(k) || v.blank?
+      !%w[as collection disabled label placeholder required minlength maxlength].include?(k) || v.blank?
     end.symbolize_keys.merge(input_html)
   end
 

--- a/app/models/fields/field.rb
+++ b/app/models/fields/field.rb
@@ -74,7 +74,7 @@ class Field < ActiveRecord::Base
   def input_options
     input_html = {}
     attributes.reject do |k, v|
-      !%w[as collection disabled label placeholder required minlength maxlength].include?(k) || v.blank?
+      !%w[as collection disabled label placeholder minlength maxlength].include?(k) || v.blank?
     end.symbolize_keys.merge(input_html)
   end
 

--- a/app/views/accounts/_contact_info.html.haml
+++ b/app/views/accounts/_contact_info.html.haml
@@ -1,5 +1,5 @@
 - edit ||= false
-- collapsed = (@account.errors.empty? && session[:account_contact].nil?)
+- collapsed = session[:account_contact].nil?
 = subtitle :account_contact, collapsed, t(:contact_info)
 .section
   %small#account_contact_intro{ hidden_if(!collapsed) }

--- a/app/views/accounts/_top_section.html.haml
+++ b/app/views/accounts/_top_section.html.haml
@@ -2,7 +2,7 @@
   .section
     %table
       %tr
-        %td(colspan="5")
+        %td{class: (@account.errors['name'].present? ? 'fieldWithErrors' : nil)}(colspan="5")
           .label.top.req #{t :name}:
           = f.text_field :name, autofocus: true, style: "width:500px"
       %tr

--- a/app/views/accounts/_top_section.html.haml
+++ b/app/views/accounts/_top_section.html.haml
@@ -4,7 +4,7 @@
       %tr
         %td{class: (@account.errors['name'].present? ? 'fieldWithErrors' : nil)}(colspan="5")
           .label.top.req #{t :name}:
-          = f.text_field :name, autofocus: true, style: "width:500px"
+          = f.text_field :name, autofocus: true, style: "width:500px", required: "required"
       %tr
         %td
           .label #{t :assigned_to}:

--- a/app/views/campaigns/_top_section.html.haml
+++ b/app/views/campaigns/_top_section.html.haml
@@ -4,7 +4,7 @@
       %tr
         %td{class: (@campaign.errors['name'].present? ? 'fieldWithErrors' : nil)}(colspan="5")
           .label.top.req #{t :name}:
-          = f.text_field :name, autofocus: true, style: "width:500px"
+          = f.text_field :name, autofocus: true, style: "width:500px", required: "required"
       %tr
         %td
           .label #{t :start_date}:

--- a/app/views/campaigns/_top_section.html.haml
+++ b/app/views/campaigns/_top_section.html.haml
@@ -2,7 +2,7 @@
   .section
     %table
       %tr
-        %td(colspan="5")
+        %td{class: (@campaign.errors['name'].present? ? 'fieldWithErrors' : nil)}(colspan="5")
           .label.top.req #{t :name}:
           = f.text_field :name, autofocus: true, style: "width:500px"
       %tr

--- a/app/views/contacts/_top_section.html.haml
+++ b/app/views/contacts/_top_section.html.haml
@@ -3,11 +3,11 @@
   .section
     %table
       %tr
-        %td
-          .label.top.req{ class: "#{Setting.require_first_names ? 'req' : nil}" } #{t :first_name}:
+        %td{class: (@contact.errors['first_name'].present? ? 'fieldWithErrors' : nil)}
+          .label.top{ class: "#{Setting.require_first_names ? 'req' : nil}" } #{t :first_name}:
           = f.text_field :first_name, autofocus: true
         %td= spacer
-        %td
+        %td{class: (@contact.errors['last_name'].present? ? 'fieldWithErrors' : nil)}
           .label.top{ class: "#{Setting.require_last_names ? 'req' : nil}" } #{t :last_name}:
           = f.text_field :last_name
       %tr

--- a/app/views/contacts/_top_section.html.haml
+++ b/app/views/contacts/_top_section.html.haml
@@ -5,11 +5,11 @@
       %tr
         %td{class: (@contact.errors['first_name'].present? ? 'fieldWithErrors' : nil)}
           .label.top{ class: "#{Setting.require_first_names ? 'req' : nil}" } #{t :first_name}:
-          = f.text_field :first_name, autofocus: true
+          = f.text_field :first_name, autofocus: true, required: (Setting.require_first_names ? "required" : nil)
         %td= spacer
         %td{class: (@contact.errors['last_name'].present? ? 'fieldWithErrors' : nil)}
           .label.top{ class: "#{Setting.require_last_names ? 'req' : nil}" } #{t :last_name}:
-          = f.text_field :last_name
+          = f.text_field :last_name, required: (Setting.require_last_names ? "required" : nil)
       %tr
         %td
           .label #{t :email}:

--- a/app/views/fields/_group.html.haml
+++ b/app/views/fields/_group.html.haml
@@ -1,7 +1,7 @@
 - if field_group.name != 'custom_fields'
   - # Ensure field groups containing validation errors are expanded
   - required_field_names = field_group.fields.select(&:required?).map(&:name)
-  - fields_with_errors = @entity.errors.map{|e| e.attribute.to_s}
+  - fields_with_errors = f.object.errors.map{|e| e.attribute.to_s}
   - force_open = (required_field_names & fields_with_errors).any?
   - collapsed = session[field_group.key].nil? && !force_open
   %div{ id: "#{field_group.key}_container", :"data-tag" => field_group.tag.try(:name) }

--- a/app/views/fields/_group.html.haml
+++ b/app/views/fields/_group.html.haml
@@ -1,6 +1,9 @@
 - if field_group.name != 'custom_fields'
-  -# start a new section
-  - collapsed = session[field_group.key].nil?
+  - # Ensure field groups containing validation errors are expanded
+  - required_field_names = field_group.fields.select(&:required?).map(&:name)
+  - fields_with_errors = @entity.errors.map{|e| e.attribute.to_s}
+  - force_open = (required_field_names & fields_with_errors).any?
+  - collapsed = session[field_group.key].nil? && !force_open
   %div{ id: "#{field_group.key}_container", :"data-tag" => field_group.tag.try(:name) }
     = subtitle field_group.key, collapsed, t(field_group.name, default: field_group.label)
     .section

--- a/app/views/fields/_group_table.html.haml
+++ b/app/views/fields/_group_table.html.haml
@@ -2,13 +2,13 @@
   - field_group.fields.without_pairs.in_groups_of(2, false) do |group|
     %tr
       - group.each_with_index do |field, i|
-        %td
+        %td{class: (@entity.errors[field.name].present? ? 'fieldWithErrors' : nil)}
           - if field.hint.present?
             = image_tag "info_tiny.png", title: field.hint, class: "tooltip-icon"
           - if field.as == 'check_boxes'
             - value = f.object.send(field.name)
             - checked = YAML.load(value.to_s)
-          .label.top
+          .label.top{class: (field.required? ? 'req': nil)}
             = "#{field.label}:"
           = f.input_field field.name, field.input_options.merge(checked: checked)
         - if i == 0

--- a/app/views/fields/_group_table.html.haml
+++ b/app/views/fields/_group_table.html.haml
@@ -2,7 +2,7 @@
   - field_group.fields.without_pairs.in_groups_of(2, false) do |group|
     %tr
       - group.each_with_index do |field, i|
-        %td{class: (@entity.errors[field.name].present? ? 'fieldWithErrors' : nil)}
+        %td{class: (f.object.errors[field.name].present? ? 'fieldWithErrors' : nil)}
           - if field.hint.present?
             = image_tag "info_tiny.png", title: field.hint, class: "tooltip-icon"
           - if field.as == 'check_boxes'

--- a/app/views/leads/_top_section.html.haml
+++ b/app/views/leads/_top_section.html.haml
@@ -5,11 +5,11 @@
       %tr
         %td{ class: (@lead.errors['first_name'].present? ? 'fieldWithErrors' : nil)}
           .label.top{ class: "#{Setting.require_first_names ? 'req' : nil}" } #{t :first_name}:
-          = f.text_field :first_name, autofocus: true
+          = f.text_field :first_name, autofocus: true, required: (Setting.require_first_names ? "required" : nil)
         %td= spacer
         %td{ class: (@lead.errors['last_name'].present? ? 'fieldWithErrors' : nil)}
           .label.top{ class: "#{Setting.require_last_names ? 'req' : nil}" } #{t :last_name}:
-          = f.text_field :last_name
+          = f.text_field :last_name, required: (Setting.require_last_names ? "required" : nil)
       %tr
         %td
           .label #{t :email}:

--- a/app/views/leads/_top_section.html.haml
+++ b/app/views/leads/_top_section.html.haml
@@ -3,11 +3,11 @@
   .section
     %table
       %tr
-        %td
+        %td{ class: (@lead.errors['first_name'].present? ? 'fieldWithErrors' : nil)}
           .label.top{ class: "#{Setting.require_first_names ? 'req' : nil}" } #{t :first_name}:
           = f.text_field :first_name, autofocus: true
         %td= spacer
-        %td
+        %td{ class: (@lead.errors['last_name'].present? ? 'fieldWithErrors' : nil)}
           .label.top{ class: "#{Setting.require_last_names ? 'req' : nil}" } #{t :last_name}:
           = f.text_field :last_name
       %tr

--- a/app/views/opportunities/_top_section.html.haml
+++ b/app/views/opportunities/_top_section.html.haml
@@ -2,7 +2,7 @@
   .section
     %table
       %tr
-        %td
+        %td{class: (@opportunity.errors['name'].present? ? 'fieldWithErrors' : nil)}
           .label.req.top #{t :name}:
           = f.text_field :name, autofocus: true, style: "width:325px"
         %td= spacer

--- a/app/views/opportunities/_top_section.html.haml
+++ b/app/views/opportunities/_top_section.html.haml
@@ -4,7 +4,7 @@
       %tr
         %td{class: (@opportunity.errors['name'].present? ? 'fieldWithErrors' : nil)}
           .label.req.top #{t :name}:
-          = f.text_field :name, autofocus: true, style: "width:325px"
+          = f.text_field :name, autofocus: true, style: "width:325px", required: "required"
         %td= spacer
         %td
           .label.req.top #{t :stage}:

--- a/app/views/shared/_add_comment.html.haml
+++ b/app/views/shared/_add_comment.html.haml
@@ -1,5 +1,5 @@
 - edit ||= false
-- collapsed = @comment_body.nil?  && f.object.errors.empty?
+- collapsed = session[:comment].nil?
 = subtitle :comment, collapsed, t(:comment)
 .section
   %small#comment_intro{ hidden_if(!collapsed) }

--- a/app/views/tasks/_top_section.html.haml
+++ b/app/views/tasks/_top_section.html.haml
@@ -3,10 +3,10 @@
     %tr
       %td(colspan="5")
         .label.top.req #{t :name}:
-        = f.text_field :name, autofocus: true, style: "width:500px"
+        = f.text_field :name, autofocus: true, style: "width:500px", required: "required"
     %tr
       %td
-        .label.req #{t :due}:
+        .label #{t :due}:
         - bucket = (params[:bucket].blank? ? @task.bucket : params[:bucket]) || "due_asap"
         - with_time = Setting.task_calendar_with_time
         - if @task.bucket != "specific_time"
@@ -18,11 +18,11 @@
           = f.text_field :calendar, value: f.object.due_at.strftime(fmt), style: "width:160px;", autocomplete: :off, class: (with_time ? 'datetime' : 'date')
       %td= spacer
       %td
-        .label.req #{t :assign_to}:
+        .label #{t :assign_to}:
         = user_select(:task, all_users, current_user)
       %td= spacer
       %td
-        .label.req #{t :category}:
+        .label #{t :category}:
         = f.select :category, @category, { selected: @task.category.blank? ? nil : @task.category.to_sym, include_blank: t(:select_blank) }, { style: "width:160px", class: 'select2' }
 
     - if Setting.background_info && Setting.background_info.include?(:task)


### PR DESCRIPTION
The following features have been implemented:

- all invalid core and custom fields should have red background highlighting
- required custom fields are now indicated with '*'
- field groups containing validation errors should always be expanded when returning the error messages (see screenshot)
- FIX contact first_name showing '*' even when not required
- added html5 'in browser' validation to core fields
- upon form submit, reveal any hidden invalid fields in order to facilitate correction (otherwise, user has no idea why the form won't submit) 
- FIX remove '*' from several fields in task that looked required but have no validation

![image](https://github.com/fatfreecrm/fat_free_crm/assets/149198/d407ce83-90df-464c-aa2e-7a65c0fa96fc)
