### PR TITLE
Fix changes in select2 since v3 -> v4 a while ago

### DIFF
--- a/app/assets/javascripts/crm.js.coffee
+++ b/app/assets/javascripts/crm.js.coffee
@@ -336,7 +336,10 @@
 
       # Country dropdown needs special treatment ;-)
       country = $("#" + from + "_attributes_country").select2("data")
-      $("#" + to + "_attributes_country").select2("data", country, true)
+      if country.length == 1
+        country_dropdown = $("#" + to + "_attributes_country")
+        country_dropdown.val(country[0].id)
+        country_dropdown.trigger('change')
 
 
     #----------------------------------------------------------------------------

--- a/app/assets/javascripts/crm_tags.js.coffee
+++ b/app/assets/javascripts/crm_tags.js.coffee
@@ -7,16 +7,16 @@
 
   # The multiselect tag list has listeners to load/remove fieldsets related to tags
   #----------------------------------------------------------------------------
-  $(document).on 'select2-selecting', "[name*='tag_list']", (event) ->
+  $(document).on 'select2:select', "[name*='tag_list']", (event) ->
     url      = $(this).data('url')
     asset_id = $(this).data('asset-id')
     $.get(url, {
-      tag: event.val
+      tag: event.params.data.text
       asset_id: asset_id
       collapsed: "no"
     })
 
-  $(document).on 'select2-removing', "[name*='tag_list']", (event) ->
-    $("#field_groups div[data-tag='" + event.val + "']").remove()
+  $(document).on 'select2:unselect', "[name*='tag_list']", (event) ->
+    $("#field_groups div[data-tag='" + event.params.data.text + "']").remove()
 
 ) jQuery


### PR DESCRIPTION
Some of the javascript in FFCRM was still using the old Select2 v3 API.

I used https://github.com/select2/select2/blob/develop/CHANGELOG.md#400 as a guide to update our code.

Bug fixes:
* When an entity is being editted and the user adds a tag, there should be a API call to load any custom field groups that are assigned to that tag. (The API call was not being triggered due to a renaming of Select2 events
* When editting an account and pressing "Same as billing address", the country field was not duplicated