### PR TITLE
Fix formatting base URL

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -42,7 +42,7 @@
       = render "layouts/footer"
 
     %script{type: "text/javascript"}
-      = "crm.base_url = '#{Setting.base_url}';" unless Setting.base_url.blank?
+      = "crm.base_url = '#{h Setting.base_url}';".html_safe unless Setting.base_url.blank?
       = get_browser_timezone_offset
       = content_for :javascript_epilogue
       = hook(:javascript_epilogue, self)


### PR DESCRIPTION
Non-escaped base url is breaking the footer javascript. 
Escaped to make JS work again.