### PR TITLE
Fix custom fields date pair and datetime pair not saving

### DIFF
--- a/app/controllers/admin/fields_controller.rb
+++ b/app/controllers/admin/fields_controller.rb
@@ -86,7 +86,7 @@ class Admin::FieldsController < Admin::ApplicationController
     field_ids = params["fields_field_group_#{field_group_id}"] || []
 
     field_ids.each_with_index do |id, index|
-      Field.where(id:).update_all(position: index + 1, field_group_id:)
+      Field.where(id: id).update_all(position: index + 1, field_group_id: field_group_id)
     end
 
     render nothing: true
@@ -101,8 +101,8 @@ class Admin::FieldsController < Admin::ApplicationController
                Field.find(id).tap { |f| f.as = as }
              else
                field_group_id = field[:field_group_id]
-               klass = Field.lookup_class(as).safe_constantize
-               klass.new(field_group_id:, as:)
+               klass = find_class(Field.lookup_class(as))
+               klass.new(field_group_id: field_group_id, as: as)
       end
 
     respond_with(@field) do |format|

--- a/app/controllers/admin/fields_controller.rb
+++ b/app/controllers/admin/fields_controller.rb
@@ -42,11 +42,11 @@ class Admin::FieldsController < Admin::ApplicationController
   #----------------------------------------------------------------------------
   def create
     as = field_params["as"]
+    klass= Field.lookup_class(as).safe_constantize
     @field =
       if as.match?(/pair/)
-        CustomFieldPair.create_pair("pair" => pair_params, "field" => field_params).first
+        klass.create_pair("pair" => pair_params, "field" => field_params).first
       elsif as.present?
-        klass = find_class(Field.lookup_class(as))
         klass.create(field_params)
       else
         Field.new(field_params).tap(&:valid?)
@@ -101,7 +101,7 @@ class Admin::FieldsController < Admin::ApplicationController
                Field.find(id).tap { |f| f.as = as }
              else
                field_group_id = field[:field_group_id]
-               klass = find_class(Field.lookup_class(as))
+               klass = Field.lookup_class(as).safe_constantize
                klass.new(field_group_id: field_group_id, as: as)
       end
 
@@ -113,13 +113,11 @@ class Admin::FieldsController < Admin::ApplicationController
   protected
 
   def field_params
-    # Sets the +permitted+ attribute to +true+. This can be used to pass
-    # mass assignment. Returns +self+.
-    params.require(:field).permit!
+    params.require(:field).permit(:as, :collection_string, :disabled, :field_group_id, :hint, :label, :maxlength, :minlength, :name, :pair_id, :placeholder, :position, :required, :settings, :type)
   end
 
   def pair_params
-    params.require(:pair).permit!
+    params.require(:pair).permit("0": [:hint, :required, :disabled, :id], "1": [:hint, :required, :disabled, :id])
   end
 
   def setup_current_tab

--- a/app/models/fields/custom_field_pair.rb
+++ b/app/models/fields/custom_field_pair.rb
@@ -12,10 +12,9 @@ class CustomFieldPair < CustomField
   #------------------------------------------------------------------------------
   def self.create_pair(params)
     fields = params['field']
-    as = params['field']['as']
-    pair = params.delete('pair')
+    pair = params['pair']
     base_params = fields.delete_if { |k, _v| !%w[field_group_id label as].include?(k) }
-    klass = ("custom_field_" + as.gsub('pair', '_pair')).classify.constantize
+    klass = ("custom_field_" + fields['as'].gsub('pair', '_pair')).classify.constantize
     field1 = klass.create(base_params.merge(pair['0']))
     field2 = klass.create(base_params.merge(pair['1']).merge('pair_id' => field1.id, 'required' => field1.required, 'disabled' => field1.disabled))
     [field1, field2]
@@ -25,9 +24,9 @@ class CustomFieldPair < CustomField
   #------------------------------------------------------------------------------
   def self.update_pair(params)
     fields = params['field']
-    pair = params.delete('pair')
+    pair = params['pair']
     base_params = fields.delete_if { |k, _v| !%w[field_group_id label as].include?(k) }
-    field1 = CustomFieldPair.find(params['id'])
+    field1 = CustomFieldPair.find(pair['0']['id'])
     field1.update(base_params.merge(pair['0']))
     field2 = field1.paired_with
     field2.update(base_params.merge(pair['1']).merge('required' => field1.required, 'disabled' => field1.disabled))
@@ -37,7 +36,7 @@ class CustomFieldPair < CustomField
   # Returns the field that this field is paired with
   #------------------------------------------------------------------------------
   def paired_with
-    pair || CustomFieldPair.where(pair_id: id).first
+    pair
   end
 
   ActiveSupport.run_load_hooks(:fat_free_crm_custom_field_pair, self)

--- a/app/models/fields/custom_field_pair.rb
+++ b/app/models/fields/custom_field_pair.rb
@@ -14,7 +14,7 @@ class CustomFieldPair < CustomField
     fields = params['field']
     pair = params['pair']
     base_params = fields.delete_if { |k, _v| !%w[field_group_id label as].include?(k) }
-    klass = ("custom_field_" + fields['as'].gsub('pair', '_pair')).classify.constantize
+    klass = Field.lookup_class(fields['as']).safe_constantize
     field1 = klass.create(base_params.merge(pair['0']))
     field2 = klass.create(base_params.merge(pair['1']).merge('pair_id' => field1.id, 'required' => field1.required, 'disabled' => field1.disabled))
     [field1, field2]
@@ -33,10 +33,10 @@ class CustomFieldPair < CustomField
     [field1, field2]
   end
 
-  # Returns the field that this field is paired with
+  # Returns the field that this field is paired with (bi-directional)
   #------------------------------------------------------------------------------
   def paired_with
-    pair
+    pair || self.class.find_by_id(pair_id)
   end
 
   ActiveSupport.run_load_hooks(:fat_free_crm_custom_field_pair, self)

--- a/app/views/admin/custom_fields/_date_pair_field.html.haml
+++ b/app/views/admin/custom_fields/_date_pair_field.html.haml
@@ -1,5 +1,5 @@
 - field1 = f.object || CustomFieldPair.new
-- field2 = f.object.respond_to?(:paired_with) ? field1.paired_with : CustomFieldPair.new
+- field2 = (field1.pair || CustomFieldPair.new)
 
 %table{class: :pairs}
   = fields_for("pair[0]", field1) do |first|

--- a/lib/fat_free_crm/custom_fields.rb
+++ b/lib/fat_free_crm/custom_fields.rb
@@ -8,7 +8,8 @@
 
 #
 # Register CustomFields when Field class is loaded
+
 ActiveSupport.on_load(:fat_free_crm_field) do # self == Field
-  CustomFieldDatePair.register(as: 'date_pair', klass: 'CustomFieldDatePair', type: 'date')
-  CustomFieldDatetimePair.register(as: 'datetime_pair', klass: 'CustomFieldDatetimePair', type: 'timestamp')
+  register(as: 'date_pair', klass: 'CustomFieldDatePair', type: 'date')
+  register(as: 'datetime_pair', klass: 'CustomFieldDatetimePair', type: 'timestamp')
 end

--- a/lib/fat_free_crm/custom_fields.rb
+++ b/lib/fat_free_crm/custom_fields.rb
@@ -9,6 +9,6 @@
 #
 # Register CustomFields when Field class is loaded
 ActiveSupport.on_load(:fat_free_crm_field) do # self == Field
-  register(as: 'date_pair', klass: 'CustomFieldDatePair', type: 'date')
-  register(as: 'datetime_pair', klass: 'CustomFieldDatetimePair', type: 'timestamp')
+  CustomFieldDatePair.register(as: 'date_pair', klass: 'CustomFieldDatePair', type: 'date')
+  CustomFieldDatetimePair.register(as: 'datetime_pair', klass: 'CustomFieldDatetimePair', type: 'timestamp')
 end

--- a/spec/controllers/admin/fields_controller_spec.rb
+++ b/spec/controllers/admin/fields_controller_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2008-2013 Michael Dvorkin and contributors.
+#
+# Fat Free CRM is freely distributable under the terms of MIT license.
+# See MIT-LICENSE file or http://www.opensource.org/licenses/mit-license.php
+#------------------------------------------------------------------------------
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe Admin::FieldsController do
+
+  before(:each) do
+    login_admin
+    set_current_tab(:fields)
+  end
+
+  let(:field_group) { FactoryBot.create(:field_group) }
+
+  describe "create" do
+    it "should create a new custom field" do
+      post :create, params: { field: { as: "email", label: "Email", field_group_id: field_group.id } }, xhr: true
+      expect(assigns[:field].class).to eq(CustomField)
+      expect(assigns[:field].valid?).to eq(true)
+      expect(assigns[:field].label).to eq("Email")
+      expect(response).to render_template("admin/fields/create")
+    end
+
+    it "should create a new custom field pair" do
+      post :create, params: { field: { as: "date_pair", label: "Date Pair", field_group_id: field_group.id }, pair: {"0" => {hint: "Hint"}, "1" => {hint: "Hint"}} }, xhr: true
+      expect(assigns[:field].class).to eq(CustomFieldDatePair)
+      expect(assigns[:field].valid?).to eq(true)
+      expect(assigns[:field].label).to eq("Date Pair")
+      expect(response).to render_template("admin/fields/create")
+    end
+  end
+
+end


### PR DESCRIPTION
In Custom Field admin, it was not possible to create date_pair and datetime_pair due to errors in parameter passing and find_class methods.

This PR cleans up the pair parameters (strong params issues) and ensures CustomFieldDatePair and CustomFieldDateTimePair classes are seen by Rails on startup.