### PR TITLE
Fix multiple custom field groups on new entity creation

### DIFF
--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -83,7 +83,7 @@ class EntitiesController < ApplicationController
   #----------------------------------------------------------------------------
   def field_group
     if @tag = Tag.find_by_name(params[:tag].strip)
-      if @field_groups = FieldGroup.where(tag_id: @tag.id, klass_name: klass.to_s)
+      if @field_groups = FieldGroup.where(tag_id: @tag.id, klass_name: klass.to_s).order(:label, :created_at)
         @asset = klass.find_by_id(params[:asset_id]) || klass.new
         render('fields/group') && return
       end

--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -83,7 +83,7 @@ class EntitiesController < ApplicationController
   #----------------------------------------------------------------------------
   def field_group
     if @tag = Tag.find_by_name(params[:tag].strip)
-      if @field_group = FieldGroup.find_by_tag_id_and_klass_name(@tag.id, klass.to_s)
+      if @field_groups = FieldGroup.where(tag_id: @tag.id, klass_name: klass.to_s)
         @asset = klass.find_by_id(params[:asset_id]) || klass.new
         render('fields/group') && return
       end

--- a/app/views/fields/group.js.erb
+++ b/app/views/fields/group.js.erb
@@ -1,3 +1,5 @@
 <%= simple_fields_for(@asset) do |f| %>
-  $('#field_groups').append('<%= j render(partial: 'fields/group', locals: {f: f, field_group: @field_group, fields: @field_group.fields}) %>')
+  <% @field_groups.each do |field_group| %>
+    $('#field_groups').append('<%= j render(partial: 'fields/group', locals: {f: f, field_group: field_group, fields: field_group.fields}) %>')
+  <% end %>
 <% end %>


### PR DESCRIPTION
This code fixes introduces new code to handle multiple field groups in the following scenario:

* Create a tag called 'Tag1'
* Create two Contact field groups that are both tagged with Tag1.
* Create at least one custom field in each field group
* Create a new contact and add 'Tag1'

Expected outcome:
* Both field groups are ajax-loaded into the form

Actual outcome:
* Only one of the field groups is ajax-loaded

