### PR TITLE
Deleting a campaign shouldn't delete related leads and opportunities.

### DIFF
--- a/app/models/entities/campaign.rb
+++ b/app/models/entities/campaign.rb
@@ -35,8 +35,8 @@ class Campaign < ActiveRecord::Base
   belongs_to :user, optional: true # TODO: Is this really optional?
   belongs_to :assignee, class_name: "User", foreign_key: :assigned_to, optional: true # TODO: Is this really optional?
   has_many :tasks, as: :asset, dependent: :destroy # , :order => 'created_at DESC'
-  has_many :leads, -> { order "id DESC" }, dependent: :destroy
-  has_many :opportunities, -> { order "id DESC" }, dependent: :destroy
+  has_many :leads, -> { order "id DESC" }
+  has_many :opportunities, -> { order "id DESC" }
   has_many :emails, as: :mediator
 
   serialize :subscribed_users, Array


### PR DESCRIPTION
I was intrigued to find that deleting a campaign also deletes leads and opportunities (and has done so for many years).

I'm wondering if this is a long-standing bug or intentional behaviour?

I've submitted a pull-request to remove this behaviour if we decide we want to go that route.

I've also noticed that related tasks are deleted whenever their parent Account, Contact, Opportunity etc are deleted. I think that makes sense but happy to be pursuaded otherwise.