### PR TITLE
Settings attributes are unknown at runtime so must be arbitarily whitelisted

### DIFF
--- a/app/controllers/admin/fields_controller.rb
+++ b/app/controllers/admin/fields_controller.rb
@@ -113,7 +113,7 @@ class Admin::FieldsController < Admin::ApplicationController
   protected
 
   def field_params
-    params.require(:field).permit(:as, :collection_string, :disabled, :field_group_id, :hint, :label, :maxlength, :minlength, :name, :pair_id, :placeholder, :position, :required, :settings, :type)
+    params.require(:field).permit(:as, :collection_string, :disabled, :field_group_id, :hint, :label, :maxlength, :minlength, :name, :pair_id, :placeholder, :position, :required, :type, settings: {})
   end
 
   def pair_params


### PR DESCRIPTION
When saving a custom field that contains settings (e.g. ffcrm_lookup_field), the nested settings params hash must be whitelisted to allow any value.