### PR TITLE
Added a placeholder to ensure the 'x' button works on Select2 dropdown

### DIFF
--- a/app/views/accounts/_top_section.html.haml
+++ b/app/views/accounts/_top_section.html.haml
@@ -12,7 +12,7 @@
         %td= spacer
         %td
           .label #{t :category}:
-          = f.select :category, Setting.unroll(:account_category), { selected: (@account.category || "other").to_sym, include_blank: t(:other) }, { style: "width:160px", class: 'select2' }
+          = f.select :category, Setting.unroll(:account_category), { selected: (@account.category || "other").to_sym, include_blank: t(:other) }, { style: "width:160px", class: 'select2', placeholder: t(:other) }
         %td= spacer
         %td
           .label #{t :rating}:


### PR DESCRIPTION
When creating or editting an account, the category dropdown doesn't clear when you press 'x' on the Select2 dialog. This is because the placeholder text is missing.

This PR adds the placeholder text and fixes the JS error.