### PR TITLE
Fix Selenium Chrome options

### DIFF
--- a/spec/features/support/browser.rb
+++ b/spec/features/support/browser.rb
@@ -9,20 +9,20 @@ Capaybara.app_host = ENV['APP_URL'] if ENV['APP_URL']
 Capybara.default_max_wait_time = 7
 Capybara.server = :webrick
 
+# For local testing in an environment with a display or remote X server configured
+# such as WSL2, use NO_HEADLESS=1 bundle exec rspec spec/features
 if ENV['BROWSER'] == 'chrome'
   Capybara.register_driver :selenium do |app|
-    options = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: { args: %w[no-sandbox headless disable-gpu] })
+    options = Selenium::WebDriver::Options.chrome
+    options.add_argument('--headless') unless ENV['NO_HEADLESS'].present?
     Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
   end
 else
-  # For local testing in an environment with a display or remote X server configured
-  # such as WSL2, use NO_HEADLESS=1 bundle exec rspec spec/features
-  #
-  # NB the marionette setting is deprecated. For modern firefox, install the geckodriver.
+  # NB the marionette setting is deprecated.
+  # For modern firefox, sudo apt-get install firefox, geckodriver will be included.
   Capybara.register_driver :selenium do |app|
     options = Selenium::WebDriver::Options.firefox
     options.add_argument('-headless') unless ENV['NO_HEADLESS'].present?
-
     Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
   end
 end


### PR DESCRIPTION
Since  [DEPRECATION] Remote::Capabilities.chrome is deprecated. Use Options.chrome instead.

Removed unnecessary argument
1. disable-gpu not needed anymore Ref: https://issues.chromium.org/issues/40527919
2. no-sandbox not needed anymore Ref: https://selenide.org/2023/05/08/selenide-6.14.0/#remove-flag--no-sandbox

Respect NO_HEADLESS=1 for chrome