### PR TITLE
Fix Rails.application.secrets deprecation warning in Devise config

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -16,6 +16,7 @@ Devise.setup do |config|
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = SecureRandom.hex(64)
+  config.secret_key = Rails.application.secret_key_base
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,


### PR DESCRIPTION
Fix the warning 
`DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from <top (required)> at /home/slau/fat_free_crm/config/environment.rb:5)`

Ref: https://github.com/heartcombo/devise/issues/5644