### PR TITLE
Remove Test ENV condition

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -63,9 +63,7 @@ class UsersController < ApplicationController
         end
       end
       responds_to_parent do
-        # Without return RSpec2 screams bloody murder about rendering twice:
-        # within the block and after yield in responds_to_parent.
-        render && (return if Rails.env.test?)
+        render
       end
     end
   end

--- a/lib/fat_free_crm/mail_processor/base.rb
+++ b/lib/fat_free_crm/mail_processor/base.rb
@@ -104,10 +104,8 @@ module FatFreeCRM
               discard(uid)
             end
           rescue Exception => e
-            if %w[test development].include?(Rails.env)
-              warn e
-              warn e.backtrace
-            end
+            warn e
+            warn e.backtrace
             log "error processing email: #{e.inspect}", email
             discard(uid)
           end
@@ -181,12 +179,10 @@ module FatFreeCRM
       # Centralized logging.
       #--------------------------------------------------------------------------------------
       def log(message, email = nil)
-        unless %w[test cucumber].include?(Rails.env)
-          klass = self.class.to_s.split("::").last
-          klass << " [Dry Run]" if @dry_run
-          puts "[#{Time.now.rfc822}] #{klass}: #{message}"
-          puts "[#{Time.now.rfc822}] #{klass}: From: #{email.from}, Subject: #{email.subject} (#{email.message_id})" if email
-        end
+        klass = self.class.to_s.split("::").last
+        klass << " [Dry Run]" if @dry_run
+        Rails.logger.info("[#{Time.now.rfc822}] #{klass}: #{message}")
+        Rails.logger.info("[#{Time.now.rfc822}] #{klass}: From: #{email.from}, Subject: #{email.subject} (#{email.message_id})") if email
       end
 
       # Returns the plain-text version of an email, or strips html tags


### PR DESCRIPTION
We also tried to remove test env condition in lib/fat_free_crm/gem_ext/action_controller/base.rb but rspec ./spec/views/admin/field_groups/create.js.haml_spec.rb:18 is failing

  1) admin/field_groups/create renders javascript
     Failure/Error: = select :field, :as, field_edit_as_options(@field), include_blank: true, id: nil, class: 'select2'

     ActionView::Template::Error:
       undefined method `field_edit_as_options' for #<#<Class:0x00007f3f91b38350>:0x00007f3f90e13878>