### PR TITLE
Don't send comment email to suspended or inactive users.

### DIFF
--- a/app/models/polymorphic/comment.rb
+++ b/app/models/polymorphic/comment.rb
@@ -54,7 +54,7 @@ class Comment < ActiveRecord::Base
   def notify_subscribers
     commentable.subscribed_users.reject { |user_id| user_id == user.id }.each do |subscriber_id|
       subscriber = User.find_by_id(subscriber_id)
-      if subscriber && subscriber.confirmed? && !subscriber.awaits_approval? && !subscriber.suspended? && subscriber.email.present?
+      if subscriber&.confirmed? && !subscriber.awaits_approval? && !subscriber.suspended? && subscriber.email.present?
         SubscriptionMailer.comment_notification(subscriber, self).deliver_later
       end
     end

--- a/app/models/polymorphic/comment.rb
+++ b/app/models/polymorphic/comment.rb
@@ -52,11 +52,9 @@ class Comment < ActiveRecord::Base
 
   # Notify subscribed users when a comment is added, unless user created this comment
   def notify_subscribers
-    commentable.subscribed_users.reject { |user_id| user_id == user.id }.each do |subscriber_id|
-      subscriber = User.find_by_id(subscriber_id)
-      if subscriber&.confirmed? && !subscriber.awaits_approval? && !subscriber.suspended? && subscriber.email.present?
-        SubscriptionMailer.comment_notification(subscriber, self).deliver_later
-      end
+    users_to_notify = User.where(id: commentable.subscribed_users.reject { |user_id| user_id == user.id })
+    users_to_notify.select(&:emailable?).each do |subscriber|
+      SubscriptionMailer.comment_notification(subscriber, self).deliver_later
     end
   end
 

--- a/app/models/polymorphic/comment.rb
+++ b/app/models/polymorphic/comment.rb
@@ -53,7 +53,8 @@ class Comment < ActiveRecord::Base
   # Notify subscribed users when a comment is added, unless user created this comment
   def notify_subscribers
     commentable.subscribed_users.reject { |user_id| user_id == user.id }.each do |subscriber_id|
-      if subscriber = User.find_by_id(subscriber_id)
+      subscriber = User.find_by_id(subscriber_id)
+      if subscriber && subscriber.confirmed? && !subscriber.awaits_approval? && !subscriber.suspended? && subscriber.email.present?
         SubscriptionMailer.comment_notification(subscriber, self).deliver_later
       end
     end

--- a/app/models/users/user.rb
+++ b/app/models/users/user.rb
@@ -134,6 +134,12 @@ class User < ActiveRecord::Base
     end
   end
 
+  # Send emails to active users only
+  #----------------------------------------------------------------------------
+  def emailable?
+    confirmed? && !awaits_approval? && !suspended? && email.present?
+  end
+
   #----------------------------------------------------------------------------
   def preference
     @preference ||= preferences.build

--- a/spec/factories/user_factories.rb
+++ b/spec/factories/user_factories.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
     deleted_at          { nil }
     updated_at          { FactoryBot.generate(:time) }
     created_at          { FactoryBot.generate(:time) }
+    confirmed_at        { Time.now.utc }
     suspended_at        { nil }
     password            { "password" }
     password_confirmation { "password" }

--- a/spec/features/devise/sign_in_spec.rb
+++ b/spec/features/devise/sign_in_spec.rb
@@ -15,7 +15,8 @@ feature 'Devise Sign-in' do
                    password: 'password',
                    password_confirmation: 'password',
                    email: 'john@example.com',
-                   sign_in_count: 0
+                   sign_in_count: 0,
+                   confirmed_at: nil
   end
 
   scenario 'without confirmation' do

--- a/spec/models/users/user_spec.rb
+++ b/spec/models/users/user_spec.rb
@@ -235,4 +235,24 @@ describe User do
       expect(search.first).to eql(user)
     end
   end
+
+  describe "emailable?" do
+    let(:user) { create(:user) }
+    it "should return true for standard user" do
+      expect(user.emailable?).to eql(true)
+    end
+    it "should return false for unconfirmed user" do
+      user.update(confirmed_at: nil)
+      expect(user.emailable?).to eql(false)
+    end
+    it "should return false for user awaiting approval" do
+      user.update(sign_in_count: 0, suspended_at: Time.now)
+      allow(Setting).to receive(:user_signup).and_return(:not_allowed)
+      expect(user.emailable?).to eql(false)
+    end
+    it "should return false for suspended user" do
+      user.update(suspended_at: Time.now)
+      expect(user.emailable?).to eql(false)
+    end
+  end
 end


### PR DESCRIPTION
Users who are suspended, inactive or not yet confirmed should not receive comment notifications.