### PR TITLE
Edit UX: Swap to email_field, phone_field, url_field as appropriate

### DIFF
--- a/app/views/accounts/_contact_info.html.haml
+++ b/app/views/accounts/_contact_info.html.haml
@@ -12,23 +12,23 @@
             %tr
               %td
                 .label #{t :phone_toll_free}:
-                = f.text_field :toll_free_phone, style: "width:154px"
+                = f.phone_field :toll_free_phone, style: "width:154px"
               %td= spacer
               %td
                 .label #{t :phone}:
-                = f.text_field :phone, style: "width:154px"
+                = f.phone_field :phone, style: "width:154px"
               %td= spacer
               %td
                 .label #{t :fax}:
-                = f.text_field :fax, style: "width:154px"
+                = f.phone_field :fax, style: "width:154px"
       %tr
         %td
           .label.top #{t :website}:
-          = f.text_field :website
+          = f.url_field :website
         %td= spacer
         %td
           .label.top Email:
-          = f.text_field :email
+          = f.email_field :email
       %tr
         %td
           = render "shared/address", f: f, asset: @account, type: :billing, title: :billing_address

--- a/app/views/contacts/_extra.html.haml
+++ b/app/views/contacts/_extra.html.haml
@@ -18,11 +18,11 @@
         %tr
           %td
             .label #{t :alt_email}:
-            = f.text_field :alt_email
+            = f.email_field :alt_email
           %td= spacer
           %td
             .label #{t :mobile}:
-            = f.text_field :mobile
+            = f.phone_field :mobile
         %tr
           %td
             = render "shared/address", f: f, asset: @contact, type: 'business', title: :address

--- a/app/views/contacts/_top_section.html.haml
+++ b/app/views/contacts/_top_section.html.haml
@@ -13,11 +13,11 @@
       %tr
         %td
           .label #{t :email}:
-          = f.text_field :email
+          = f.email_field :email
         %td= spacer
         %td
           .label #{t :phone}:
-          = f.text_field :phone
+          = f.phone_field :phone
 
     %table
       = fields_for(@account) do |a|

--- a/app/views/contacts/_web.html.haml
+++ b/app/views/contacts/_web.html.haml
@@ -9,7 +9,7 @@
       %tr
         %td
           .label.top #{t :blog}:
-          = f.text_field :blog
+          = f.url_field :blog
         %td= spacer
         %td
           .label.top #{t :twitter}:

--- a/app/views/leads/_contact.html.haml
+++ b/app/views/leads/_contact.html.haml
@@ -17,11 +17,11 @@
       %tr
         %td
           .label #{t :alt_email}:
-          = f.text_field :alt_email
+          = f.email_field :alt_email
         %td= spacer
         %td
           .label #{t :mobile}:
-          = f.text_field :mobile
+          = f.phone_field :mobile
       %tr
         %td
           = render "shared/address", f: f, asset: @lead, type: 'business', title: :address


### PR DESCRIPTION
This should be fairly safe, as it's only on the browser UI that it would be enforced with formatting rules.
IE if someone has invalid content, the browser will nudge them to fix when they are editing.

From spot checking the database columns, things like 'email' are short enough that it is unlikely people crammed in "email notes" or "phone notes".

<img width="1382" height="698" alt="image" src="https://github.com/user-attachments/assets/48b7731f-a5e5-41f9-9202-d953e945fc40" />

Mobile users will get the best UX boost out of this.