### PR TITLE
Rails 7.1: Fix .to_s(:format) usage

### DIFF
--- a/app/views/application/index.rss.builder
+++ b/app/views/application/index.rss.builder
@@ -15,7 +15,7 @@ xml.rss version: "2.0" do
   xml.channel do
     xml.generator  "Fat Free CRM v#{FatFreeCRM::VERSION::STRING}"
     xml.link       send(:"#{items}_url")
-    xml.pubDate    Time.now.to_s(:rfc822)
+    xml.pubDate    Time.now.to_fs(:rfc822)
     xml.title      title || t(items.to_sym)
 
     assets.each do |asset|
@@ -25,7 +25,7 @@ xml.rss version: "2.0" do
         xml.description send(:"#{item}_summary", asset) if respond_to?(:"#{item}_summary")
         xml.guid        url
         xml.link        url
-        xml.pubDate     asset.created_at.to_s(:rfc822)
+        xml.pubDate     asset.created_at.to_fs(:rfc822)
         xml.title       !asset.is_a?(User) ? asset.name : "#{asset.full_name} (#{asset.username})"
       end
     end

--- a/app/views/application/show.rss.builder
+++ b/app/views/application/show.rss.builder
@@ -13,7 +13,7 @@ xml.rss version: "2.0" do
   xml.channel do
     xml.generator  "Fat Free CRM v#{FatFreeCRM::VERSION::STRING}"
     xml.link       send(:"#{@items}_url")
-    xml.pubDate    Time.now.to_s(:rfc822)
+    xml.pubDate    Time.now.to_fs(:rfc822)
     xml.title      title || t(@items.to_sym)
 
     @assets.each do |asset|
@@ -23,7 +23,7 @@ xml.rss version: "2.0" do
         xml.description send(:"#{item}_summary", asset) if respond_to?(:"#{item}_summary")
         xml.guid        url
         xml.link        url
-        xml.pubDate     asset.created_at.to_s(:rfc822)
+        xml.pubDate     asset.created_at.to_fs(:rfc822)
         xml.title       !asset.is_a?(User) ? asset.name : "#{asset.full_name} (#{asset.username})"
       end
     end

--- a/app/views/home/index.rss.builder
+++ b/app/views/home/index.rss.builder
@@ -6,7 +6,7 @@ xml.rss version: "2.0" do
   xml.channel do
     xml.generator  "Fat Free CRM v#{FatFreeCRM::VERSION::STRING}"
     xml.link       root_url
-    xml.pubDate    Time.now.to_s(:rfc822)
+    xml.pubDate    Time.now.to_fs(:rfc822)
     xml.title      t(:activities)
 
     @activities.each do |activity|
@@ -14,7 +14,7 @@ xml.rss version: "2.0" do
         xml.author      activity.user.try(:full_name)
         # xml.guid        activity.id
         # xml.link        nil
-        xml.pubDate     activity.created_at.to_s(:rfc822)
+        xml.pubDate     activity.created_at.to_fs(:rfc822)
         xml.title       activity_title(activity)
       end
     end

--- a/db/demo/accounts.yml
+++ b/db/demo/accounts.yml
@@ -42,6 +42,6 @@ account<%= i %>:
   background_info  : <%= "#{FFaker::Company.catch_phrase} #{FFaker::Company.bs}" %>
   rating           : <%= rand(5) %>
   category         : <%= category.sample %>
-  created_at       : <%= created_at = (rand(60) + 2).days.ago + rand(600).minutes; created_at.to_s(:db) %>
-  updated_at       : <%= (created_at + rand(36_000).seconds).to_s(:db) %>
+  created_at       : <%= created_at = (rand(60) + 2).days.ago + rand(600).minutes; created_at.to_fs(:db) %>
+  updated_at       : <%= (created_at + rand(36_000).seconds).to_fs(:db) %>
 <% end %>

--- a/db/demo/campaigns.yml
+++ b/db/demo/campaigns.yml
@@ -139,6 +139,6 @@ campaign<%= i %>:
   objectives          : <%= FFaker::Lorem.sentence %>
   background_info     :
 # background_info     : <%= FFaker::Lorem.paragraph[0,255] %>
-  created_at          : <%= created_at = (rand(60) + 2).days.ago + rand(600).minutes; created_at.to_s(:db) %>
-  updated_at          : <%= (created_at + rand(36_000).seconds).to_s(:db) %>
+  created_at          : <%= created_at = (rand(60) + 2).days.ago + rand(600).minutes; created_at.to_fs(:db) %>
+  updated_at          : <%= (created_at + rand(36_000).seconds).to_fs(:db) %>
 <% end %>

--- a/db/demo/contacts.yml
+++ b/db/demo/contacts.yml
@@ -63,8 +63,8 @@ contact_<%= i %>:
   skype       : <%= %[#{(first_name + last_name.first).downcase}] if rand(10) < 8 %>
   born_on     : <%= Date.today - (rand(20) + 20).years - rand(200).days %>
   do_not_call : false
-  created_at  : <%= created_at = (rand(60) + 2).days.ago + rand(600).minutes; created_at.to_s(:db) %>
-  updated_at  : <%= (created_at + rand(36_000).seconds).to_s(:db) %>
+  created_at  : <%= created_at = (rand(60) + 2).days.ago + rand(600).minutes; created_at.to_fs(:db) %>
+  updated_at  : <%= (created_at + rand(36_000).seconds).to_fs(:db) %>
   background_info : <%= FFaker::Lorem.paragraph[0,255] %>
 <% end %>
 

--- a/db/demo/leads.yml
+++ b/db/demo/leads.yml
@@ -65,7 +65,7 @@ lead<%= i %>:
   phone       : <%= FFaker::PhoneNumber.short_phone_number if rand(10) < 5 %>
   mobile      : <%= FFaker::PhoneNumber.short_phone_number if rand(10) < 3 %>
   do_not_call : false
-  created_at  : <%= created_at = (rand(60) + 2).days.ago + rand(600).minutes; created_at.to_s(:db) %>
-  updated_at  : <%= (created_at + rand(36_000).seconds).to_s(:db) %>
+  created_at  : <%= created_at = (rand(60) + 2).days.ago + rand(600).minutes; created_at.to_fs(:db) %>
+  updated_at  : <%= (created_at + rand(36_000).seconds).to_fs(:db) %>
   background_info : <%= FFaker::Lorem.paragraph[0,255] %>
 <% end %>

--- a/db/demo/opportunities.yml
+++ b/db/demo/opportunities.yml
@@ -42,7 +42,7 @@ opportunity_<%= i %>:
   amount      : <%= (rand(8) + 1) * 100_000 %>
   closes_on   : <%= Date.today + (rand(100) + 10).days %>
   background_info :
-  created_at  : <%= created_at = (rand(60) + 2).days.ago + rand(600).minutes; created_at.to_s(:db) %>
-  updated_at  : <%= (created_at + rand(36_000).seconds).to_s(:db) %>
+  created_at  : <%= created_at = (rand(60) + 2).days.ago + rand(600).minutes; created_at.to_fs(:db) %>
+  updated_at  : <%= (created_at + rand(36_000).seconds).to_fs(:db) %>
   background_info : <%= FFaker::Lorem.paragraph[0,255] %>
 <% end %>

--- a/db/demo/tasks.yml
+++ b/db/demo/tasks.yml
@@ -59,6 +59,6 @@ task<%= i %>:
 # background_info : <%= FFaker::Lorem.paragraph[0,255] %>
   due_at       : <%= due_at %>
   completed_at : <%= completed_by ? Date.today - rand(5).days : "" %>
-  created_at   : <%= created_at = (rand(60) + 2).days.ago + rand(600).minutes; created_at.to_s(:db) %>
-  updated_at   : <%= (created_at + rand(36_000).seconds).to_s(:db) %>
+  created_at   : <%= created_at = (rand(60) + 2).days.ago + rand(600).minutes; created_at.to_fs(:db) %>
+  updated_at   : <%= (created_at + rand(36_000).seconds).to_fs(:db) %>
 <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_26_212613) do
+ActiveRecord::Schema[7.1].define(version: 2023_05_26_212613) do
   create_table "account_contacts", force: :cascade do |t|
     t.integer "account_id"
     t.integer "contact_id"


### PR DESCRIPTION
Oops, looks like we don't have coverage of the loading seed data rake tasks; a few other places here.
```
ArgumentError: wrong number of arguments (given 1, expected 0) (ArgumentError)
/usr/local/rvm/gems/ruby-3.4.5/gems/activesupport-7.1.5.1/lib/active_support/time_with_zone.rb:200:in 'to_s'
```