### PR TITLE
Add ReadAI webhook controller and route

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,9 +200,7 @@ GEM
       rails-i18n
     diff-lcs (1.6.1)
     drb (2.2.3)
-    dynamic_form (1.3.1)
-      actionview (> 5.2.0)
-      activemodel (> 5.2.0)
+    dynamic_form (1.2.0)
     email_reply_parser_ffcrm (0.5.0)
     erb (5.0.2)
     erubi (1.13.1)

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -10,22 +10,20 @@ class WebhooksController < ApplicationController
     owner_email = payload.dig("owner", "email")
     user = User.find_by(email: owner_email)
 
-    if user.nil?
-      return head :not_found
-    end
+    return head :not_found if user.nil?
 
     ActiveRecord::Base.transaction do
       payload["participants"].each do |participant|
-        participant_email = participant["email"]
+        participant["email"]
         lead_or_contact = find_or_create_lead_or_contact(participant)
 
-        if lead_or_contact
-          # Create a Note
-          lead_or_contact.notes.create(
-            user: user,
-            note: "Meeting Summary: #{payload['summary']}\n\nReport URL: #{payload['report_url']}"
-          )
-        end
+        next unless lead_or_contact
+
+        # Create a Note
+        lead_or_contact.notes.create(
+          user: user,
+          note: "Meeting Summary: #{payload['summary']}\n\nReport URL: #{payload['report_url']}"
+        )
       end
 
       payload["action_items"].each do |action_item|
@@ -50,8 +48,8 @@ class WebhooksController < ApplicationController
     return lead if lead
 
     Lead.create(
-      first_name: participant["name"].split(" ").first,
-      last_name: participant["name"].split(" ").last,
+      first_name: participant["name"].split.first,
+      last_name: participant["name"].split.last,
       email: participant["email"],
       user: User.first # Or assign to a default user
     )

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class WebhooksController < ApplicationController
+  skip_before_action :authenticate_user!
+  skip_before_action :verify_authenticity_token
+  before_action :verify_ip
+
+  def readai_meeting_notes
+    payload = JSON.parse(request.body.read)
+    owner_email = payload.dig("owner", "email")
+    user = User.find_by(email: owner_email)
+
+    if user.nil?
+      return head :not_found
+    end
+
+    ActiveRecord::Base.transaction do
+      payload["participants"].each do |participant|
+        participant_email = participant["email"]
+        lead_or_contact = find_or_create_lead_or_contact(participant)
+
+        if lead_or_contact
+          # Create a Note
+          lead_or_contact.notes.create(
+            user: user,
+            note: "Meeting Summary: #{payload['summary']}\n\nReport URL: #{payload['report_url']}"
+          )
+        end
+      end
+
+      payload["action_items"].each do |action_item|
+        Task.create(
+          user: user,
+          name: action_item["text"],
+          assigned_to: user.id
+        )
+      end
+    end
+
+    head :ok
+  end
+
+  private
+
+  def find_or_create_lead_or_contact(participant)
+    contact = Contact.find_by(email: participant["email"])
+    return contact if contact
+
+    lead = Lead.find_by(email: participant["email"])
+    return lead if lead
+
+    Lead.create(
+      first_name: participant["name"].split(" ").first,
+      last_name: participant["name"].split(" ").last,
+      email: participant["email"],
+      user: User.first # Or assign to a default user
+    )
+  end
+
+  def verify_ip
+    return if request.remote_ip == '127.0.0.1'
+
+    head :unauthorized
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,6 +162,8 @@ Rails.application.routes.draw do
     end
   end
 
+  post 'webhooks/readai_meeting_notes'
+
   namespace :admin do
     resources :groups
 


### PR DESCRIPTION
This commit introduces a new webhook to handle meeting notes from ReadAI.

- A new `WebhooksController` is added with a `readai_meeting_notes` action.
- The action is protected by an IP filter, allowing requests only from 127.0.0.1.
- A new route `POST /webhooks/readai_meeting_notes` is added.

The `readai_meeting_notes` action processes a JSON payload containing meeting details:
- It finds the meeting owner in the `users` table by email.
- It processes each participant, looking for them as a `Contact` or `Lead`. If not found, a new `Lead` is created.
- A `Note` with the meeting summary and report URL is created for each participant (Contact or Lead).
- A `Task` is created for each action item.
- All database operations are wrapped in a transaction to ensure data integrity.

# TODOs

- [ ] Reconcile this with ffcrm_endpoint / rewrite it as a handler just there.