### PR TITLE
Swap from our fork of acts_as_commentable via github, to our fork of acts_as_commentable via rubygems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
     acts-as-taggable-on (11.0.0)
       activerecord (>= 7.0, < 8.0)
       zeitwerk (>= 2.4, < 3.0)
+    acts_as_commentable2 (7.1.0.1)
+      activerecord (~> 7.1.0)
     acts_as_list (1.2.4)
       activerecord (>= 6.1)
       activesupport (>= 6.1)
@@ -576,6 +578,7 @@ DEPENDENCIES
   activemodel-serializers-xml
   acts-as-taggable-on (>= 3.4.3)
   acts_as_commentable!
+  acts_as_commentable2 (~> 7.1.0)
   acts_as_list
   base64
   bigdecimal

--- a/fat_free_crm.gemspec
+++ b/fat_free_crm.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'paper_trail',         '~> 15.1.0'
   gem.add_dependency 'devise',              '~> 4.6'
   gem.add_dependency 'devise-encryptable',  '~> 0.2.0'
-  gem.add_dependency 'acts_as_commentable', '>= 6.1'
+  gem.add_dependency 'acts_as_commentable2', '~> 7.1.0'
   gem.add_dependency 'acts-as-taggable-on', '>= 3.4.3'
   gem.add_dependency 'dynamic_form'
   gem.add_dependency 'haml'


### PR DESCRIPTION
I will figure out how to make acts_as_commentable2 owned by the organisation shortly.