### PR TITLE
Fix issues where the driver didn't load the postgres adapter

### DIFF
--- a/db/migrate/20230526212613_convert_to_active_storage.rb
+++ b/db/migrate/20230526212613_convert_to_active_storage.rb
@@ -11,8 +11,8 @@ class ConvertToActiveStorage < ActiveRecord::Migration[5.2]
                     else
                       'LASTVAL()'
                     end
-      get_blob_id = 'LAST_INSERT_ROWID()' if conn.is_a?(SQLite3::Database)
-      if conn.is_a?(::PG::Connection)
+      get_blob_id = 'LAST_INSERT_ROWID()' if Object.const_defined?("SQLite3") && conn.is_a?(SQLite3::Database)
+      if Object.const_defined?("PG") && conn.is_a?(::PG::Connection)
         get_blob_id = 'LASTVAL()'
         conn.prepare('active_storage_blobs', <<-SQL)
           INSERT INTO active_storage_blobs (


### PR DESCRIPTION
If you are running with sqlite only and pass in the right env variables you can end up with:
```
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

uninitialized constant PG
/opt/hostedtoolcache/Ruby/3.4.5/x64/bin/bundle:25:in 'Kernel#load'
/opt/hostedtoolcache/Ruby/3.4.5/x64/bin/bundle:25:in '<main>'

Caused by:
NameError: uninitialized constant PG (NameError)

      if conn.is_a?(::PG::Connection)
                    ^^^^
/opt/hostedtoolcache/Ruby/3.4.5/x64/bin/bundle:25:in 'Kernel#load'
/opt/hostedtoolcache/Ruby/3.4.5/x64/bin/bundle:25:in '<main>'
```