### PR TITLE
Add title column to Field table

### DIFF
--- a/app/controllers/admin/fields_controller.rb
+++ b/app/controllers/admin/fields_controller.rb
@@ -113,7 +113,7 @@ class Admin::FieldsController < Admin::ApplicationController
   protected
 
   def field_params
-    params.require(:field).permit(:as, :collection_string, :disabled, :field_group_id, :hint, :label, :maxlength, :minlength, :name, :pair_id, :placeholder, :position, :required, :type, settings: {})
+    params.require(:field).permit(:as, :collection_string, :disabled, :field_group_id, :hint, :label, :maxlength, :minlength, :name, :pair_id, :placeholder, :position, :required, :type, :title, settings: {})
   end
 
   def pair_params

--- a/app/models/fields/field.rb
+++ b/app/models/fields/field.rb
@@ -74,7 +74,7 @@ class Field < ActiveRecord::Base
   def input_options
     input_html = {}
     attributes.reject do |k, v|
-      !%w[as collection disabled label placeholder required minlength maxlength].include?(k) || v.blank?
+      !%w[as collection disabled label placeholder required minlength maxlength title].include?(k) || v.blank?
     end.symbolize_keys.merge(input_html)
   end
 

--- a/app/views/admin/fields/_form.html.haml
+++ b/app/views/admin/fields/_form.html.haml
@@ -17,6 +17,9 @@
           %td
             .label.top.req Field label:
             = f.text_field :label, id: nil
+          %td
+            .label.top Title:
+            = f.text_field :title, id: nil
 
           %td= spacer
           %td

--- a/db/migrate/20230526212614_add_title_to_fields.rb
+++ b/db/migrate/20230526212614_add_title_to_fields.rb
@@ -1,0 +1,5 @@
+class AddTitleToFields < ActiveRecord::Migration[7.1]
+  def change
+    add_column :fields, :title, :string
+  end
+end


### PR DESCRIPTION
This change adds a `title` column to the `Field` table and a corresponding input field in the admin UI. The `title` attribute is then used as the `title` attribute on the rendered HTML input fields for custom fields.