### PR TITLE
feat: Format phone numbers as tel: links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -170,6 +170,25 @@ module ApplicationHelper
     end
   end
 
+  # Format a phone number as a tel: hyperlink.
+  #----------------------------------------------------------------------------
+  def link_to_phone(number)
+    return nil if number.blank?
+
+    sanitized_number = number.gsub(/[^0-9+]/, '')
+    link_to number, "tel:#{sanitized_number}"
+  end
+
+  # Render a phone field with an optional pattern for international format.
+  #----------------------------------------------------------------------------
+  def phone_field_with_pattern(form, method, options = {})
+    if Setting.enforce_international_phone_format
+      options[:pattern] ||= '\+[0-9]{1,3}\s?[0-9]{1,14}'
+      options[:placeholder] ||= '+1 123 456 7890'
+    end
+    form.phone_field(method, options)
+  end
+
   #----------------------------------------------------------------------------
   def jumpbox(current)
     tabs = %i[campaigns accounts leads contacts opportunities]

--- a/app/views/accounts/_contact_info.html.haml
+++ b/app/views/accounts/_contact_info.html.haml
@@ -12,15 +12,15 @@
             %tr
               %td
                 .label #{t :phone_toll_free}:
-                = f.phone_field :toll_free_phone, style: "width:154px"
+                = phone_field_with_pattern(f, :toll_free_phone, style: "width:154px")
               %td= spacer
               %td
                 .label #{t :phone}:
-                = f.phone_field :phone, style: "width:154px"
+                = phone_field_with_pattern(f, :phone, style: "width:154px")
               %td= spacer
               %td
                 .label #{t :fax}:
-                = f.phone_field :fax, style: "width:154px"
+                = phone_field_with_pattern(f, :fax, style: "width:154px")
       %tr
         %td
           .label.top #{t :website}:

--- a/app/views/accounts/_index_long.html.haml
+++ b/app/views/accounts/_index_long.html.haml
@@ -33,7 +33,7 @@
       = stars_for(account)
       = " | ".html_safe << link_to(account.website, account.website.to_url) if account.website.present?
       = " | ".html_safe << link_to_email(account.email) if account.email.present?
-      = " | ".html_safe << t(:phone_small) << ": " << (account.toll_free_phone? ? account.toll_free_phone : account.phone) if account.toll_free_phone? || account.phone?
+      = " | ".html_safe << t(:phone_small) << ": " << (account.toll_free_phone? ? link_to_phone(account.toll_free_phone) : link_to_phone(account.phone)) if account.toll_free_phone? || account.phone?
 
     - if account.tags.present?
       %dt

--- a/app/views/accounts/_sidebar_show.html.haml
+++ b/app/views/accounts/_sidebar_show.html.haml
@@ -12,13 +12,13 @@
 
   %div
     - if @account.toll_free_phone
-      #{t :phone_toll_free}: <b>#{@account.toll_free_phone}</b><br />
+      == #{t :phone_toll_free}: <b>#{link_to_phone(@account.toll_free_phone)}</b><br />
 
     - if @account.phone
-      #{t :phone}: <b>#{@account.phone}</b><br />
+      == #{t :phone}: <b>#{link_to_phone(@account.phone)}</b><br />
 
     - if @account.fax
-      #{t :fax}: <b>#{@account.fax}</b><br />
+      == #{t :fax}: <b>#{link_to_phone(@account.fax)}</b><br />
 
   %div= render "shared/address_show", asset: @account, type: 'billing', title: :billing_address
   %div= render "shared/address_show", asset: @account, type: 'shipping', title: :shipping_address

--- a/app/views/admin/users/_user.html.haml
+++ b/app/views/admin/users/_user.html.haml
@@ -47,11 +47,13 @@
     %dt{ style: "padding: 2px 0px 0px 0px" }
       = link_to_email(user.email.to_s) + " | "
       - if user.phone?
-        = t(:phone_small) + ":"
-        = content_tag(:b, user.phone) + " | "
+        = (t(:phone_small) + ": ").html_safe
+        %b= link_to_phone(user.phone)
+        = " | ".html_safe
       - if user.mobile?
-        = t(:mobile_small) + ":"
-        = content_tag(:b, user.mobile) + " | "
+        = (t(:mobile_small) + ": ").html_safe
+        %b= link_to_phone(user.mobile)
+        = " | ".html_safe
 
       - if !user.suspended?
         %span #{t(:user_since, l(user.created_at.to_date, format: :mmddyy))}

--- a/app/views/contacts/_extra.html.haml
+++ b/app/views/contacts/_extra.html.haml
@@ -22,14 +22,14 @@
           %td= spacer
           %td
             .label #{t :mobile}:
-            = f.phone_field :mobile
+            = phone_field_with_pattern(f, :mobile)
         %tr
           %td
             = render "shared/address", f: f, asset: @contact, type: 'business', title: :address
           %td= spacer
           %td
             .label #{t :fax}:
-            = f.text_field :fax
+            = phone_field_with_pattern(f, :fax)
             %div{style: "margin-top:6px"}
               .check_box
                 = f.check_box :do_not_call, {}, true

--- a/app/views/contacts/_index_full.html.haml
+++ b/app/views/contacts/_index_full.html.haml
@@ -35,11 +35,11 @@
           |
         - if contact.phone.present?
           == #{t :phone_small}:
-          %b= contact.phone
+          %b= link_to_phone(contact.phone)
           |
         - if contact.mobile.present?
           == #{t :mobile_small}:
-          %b= contact.mobile
+          %b= link_to_phone(contact.mobile)
           |
       = t(:added_ago, value: timeago(contact.created_at)).html_safe
     - if contact.tags.present?

--- a/app/views/contacts/_index_long.html.haml
+++ b/app/views/contacts/_index_long.html.haml
@@ -29,11 +29,11 @@
           |
         - if contact.phone.present?
           == #{t :phone_small}:
-          %b= contact.phone
+          %b= link_to_phone(contact.phone)
         |
         - if contact.mobile.present?
           == #{t :mobile_small}:
-          %b= contact.mobile
+          %b= link_to_phone(contact.mobile)
           |
       = t(:added_ago, value: timeago(contact.created_at)).html_safe
 

--- a/app/views/contacts/_section_general.html.haml
+++ b/app/views/contacts/_section_general.html.haml
@@ -8,7 +8,7 @@
         = col(t(:last_name), contact.last_name)
       %tr
         = col(t(:email), contact.email, false, true)
-        = col(t(:phone), contact.phone)
+        = col(t(:phone)) { link_to_phone(contact.phone) }
       %tr
         = col(t(:account)) do
           = account_with_url_for(contact)

--- a/app/views/contacts/_sidebar_show.html.haml
+++ b/app/views/contacts/_sidebar_show.html.haml
@@ -6,11 +6,11 @@
 
   %div
     - unless @contact.phone.blank?
-      == #{t :phone}: <b>#{@contact.do_not_call ? content_tag(:strike, h(@contact.phone)) : h(@contact.phone)}</b><br />
+      == #{t :phone}: <b>#{@contact.do_not_call ? content_tag(:strike, @contact.phone) : link_to_phone(@contact.phone)}</b><br />
     - unless @contact.mobile.blank?
-      == #{t :mobile}: <b>#{@contact.do_not_call ? content_tag(:strike, h(@contact.mobile)) : h(@contact.mobile)}</b><br />
+      == #{t :mobile}: <b>#{@contact.do_not_call ? content_tag(:strike, @contact.mobile) : link_to_phone(@contact.mobile)}</b><br />
     - unless @contact.fax.blank?
-      == #{t :fax}: <b>#{@contact.do_not_call ? content_tag(:strike, h(@contact.fax)) : h(@contact.fax)}</b><br />
+      == #{t :fax}: <b>#{@contact.do_not_call ? content_tag(:strike, @contact.fax) : link_to_phone(@contact.fax)}</b><br />
   %div
     - unless @contact.email.blank?
       == #{t :email}: <b>#{link_to_email(@contact.email)}</b><br />

--- a/app/views/home/_account.html.haml
+++ b/app/views/home/_account.html.haml
@@ -20,7 +20,7 @@
       %dt
         = link_to(account.website, account.website.to_url) + " | " if account.website.present?
         = link_to_email(account.email) + " | " if account.email.present?
-        = t(:phone_small) + ": " + (account.toll_free_phone || account.phone) << " | " if account.toll_free_phone? || account.phone?
+        = (t(:phone_small) + ": ").html_safe + link_to_phone(account.toll_free_phone || account.phone) + " | ".html_safe if account.toll_free_phone? || account.phone?
         = t('pluralize.contact', account.contacts_count) + " | "
         = t('pluralize.opportunity', account.opportunities_count)
       - if account.tags.present?

--- a/app/views/leads/_contact.html.haml
+++ b/app/views/leads/_contact.html.haml
@@ -21,7 +21,7 @@
         %td= spacer
         %td
           .label #{t :mobile}:
-          = f.phone_field :mobile
+          = phone_field_with_pattern(f, :mobile)
       %tr
         %td
           = render "shared/address", f: f, asset: @lead, type: 'business', title: :address

--- a/app/views/leads/_index_long.html.haml
+++ b/app/views/leads/_index_long.html.haml
@@ -47,11 +47,11 @@
           |
         - if lead.phone.present?
           == #{t :phone_small}:
-          %b= lead.phone
+          %b= link_to_phone(lead.phone)
           |
         - if lead.mobile.present?
           == #{t :mobile_small}:
-          %b= lead.mobile
+          %b= link_to_phone(lead.mobile)
           |
       = t(:added_ago, value: timeago(lead.created_at)).html_safe
 

--- a/app/views/leads/_sidebar_show.html.haml
+++ b/app/views/leads/_sidebar_show.html.haml
@@ -11,9 +11,9 @@
 
   %div
     - if @lead.phone.present?
-      == #{t :phone}: <b>#{@lead.do_not_call ? content_tag(:strike, @lead.phone) : @lead.phone}</b><br />
+      == #{t :phone}: <b>#{@lead.do_not_call ? content_tag(:strike, @lead.phone) : link_to_phone(@lead.phone)}</b><br />
     - if @lead.mobile.present?
-      == #{t :mobile}: <b>#{@lead.do_not_call ? content_tag(:strike, @lead.mobile) : @lead.mobile}</b><br />
+      == #{t :mobile}: <b>#{@lead.do_not_call ? content_tag(:strike, @lead.mobile) : link_to_phone(@lead.mobile)}</b><br />
     - if @lead.email.present?
       == #{t :email}: <b>#{link_to_email(@lead.email)}</b><br />
     - if @lead.alt_email.present?

--- a/app/views/leads/_top_section.html.haml
+++ b/app/views/leads/_top_section.html.haml
@@ -17,7 +17,7 @@
         %td= spacer
         %td
           .label #{t :phone}:
-          = f.text_field :phone
+          = phone_field_with_pattern(f, :phone)
 
       - if Setting.background_info && Setting.background_info.include?(:lead)
         %tr

--- a/app/views/users/_profile.html.haml
+++ b/app/views/users/_profile.html.haml
@@ -36,11 +36,11 @@
         %tr
           %td{ colspan: 3 }
             .label #{t :phone}:
-            = f.text_field :phone
+            = phone_field_with_pattern(f, :phone)
           %td= spacer
           %td{ colspan: 3 }
             .label #{t :mobile}:
-            = f.text_field :mobile
+            = phone_field_with_pattern(f, :mobile)
         %tr
           %td
             .label #{t :aim}:

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -20,14 +20,15 @@
         - unless @user.alt_email.blank?
           #{t :or} #{auto_link(@user.alt_email)}
       - if !@user.phone.blank? && !@user.mobile.blank?
-        %div #{t :phone}: <b>#{@user.phone}</b>, #{t :mobile}: <b>#{@user.mobile}</b>
+        %div
+          == #{t :phone}: <b>#{link_to_phone(@user.phone)}</b>, #{t :mobile}: <b>#{link_to_phone(@user.mobile)}</b>
       - else
         - if @user.phone.present?
-          = t(:phone) + ":"
-          = content_tag(:b, @user.phone)
+          %div
+            == #{t :phone}: <b>#{link_to_phone(@user.phone)}</b>
         - if @user.mobile.present?
-          = t(:mobile) + ":"
-          = content_tag(:b, @user.mobile)
+          %div
+            == #{t :mobile}: <b>#{link_to_phone(@user.mobile)}</b>
 
 - if Setting.per_user_locale
   %script= render "languages"

--- a/config/settings.default.yml
+++ b/config/settings.default.yml
@@ -358,3 +358,11 @@ task_completed:
   - :completed_last_week
   - :completed_this_month
   - :completed_last_month
+
+# Phone Numbers
+#------------------------------------------------------------------------------
+# Enforce international phone number format (e.g. +1-555-555-5555)
+# When set to true, a 'pattern' attribute will be added to all phone input fields
+# to help guide users to enter phone numbers in international format.
+#
+:enforce_international_phone_format: false


### PR DESCRIPTION
This commit introduces the following changes:

- A new helper method `link_to_phone` is added to format phone numbers as `tel:` hyperlinks.
- All views that display phone numbers are updated to use this new helper.
- A feature toggle `enforce_international_phone_format` is added to `settings.default.yml`.
- When this feature is enabled, a `pattern` attribute is added to all phone number input fields to enforce international format.
- A new helper method `phone_field_with_pattern` is added to conditionally add the pattern to phone fields.
- All phone number input fields are updated to use this new helper.
- Tests for the new helper methods are added.


#701 