### PR TITLE
Add latitude and longitude to Account model

### DIFF
--- a/app/controllers/entities/accounts_controller.rb
+++ b/app/controllers/entities/accounts_controller.rb
@@ -54,6 +54,7 @@ class AccountsController < EntitiesController
   #----------------------------------------------------------------------------
   def create
     @comment_body = params[:comment_body]
+    @account = Account.new(account_params)
     respond_with(@account) do |_format|
       if @account.save
         @account.add_comment_by_user(@comment_body, current_user)
@@ -71,7 +72,7 @@ class AccountsController < EntitiesController
     respond_with(@account) do |_format|
       # Must set access before user_ids, because user_ids= method depends on access value.
       @account.access = params[:account][:access] if params[:account][:access]
-      get_data_for_sidebar if @account.update(resource_params)
+      get_data_for_sidebar if @account.update(account_params)
     end
   end
 
@@ -159,6 +160,27 @@ class AccountsController < EntitiesController
     categorized = @account_category_total.values.sum
     @account_category_total[:all] = Account.my(current_user).count
     @account_category_total[:other] = @account_category_total[:all] - categorized
+  end
+
+  def account_params
+    params.require(:account).permit(
+      :name,
+      :access,
+      :assigned_to,
+      :website,
+      :toll_free_phone,
+      :phone,
+      :fax,
+      :email,
+      :background_info,
+      :rating,
+      :category,
+      :subscribed_users,
+      :latitude,
+      :longitude,
+      billing_address_attributes: %i[id street1 street2 city state zipcode country address_type],
+      shipping_address_attributes: %i[id street1 street2 city state zipcode country address_type]
+    )
   end
 
   ActiveSupport.run_load_hooks(:fat_free_crm_accounts_controller, self)

--- a/app/models/entities/account.rb
+++ b/app/models/entities/account.rb
@@ -77,6 +77,8 @@ class Account < ActiveRecord::Base
   validates_uniqueness_of :name, scope: :deleted_at, if: -> { Setting.require_unique_account_names }
   validates :rating, inclusion: { in: 0..5 }, allow_blank: true
   validates :category, inclusion: { in: proc { Setting.unroll(:account_category).map { |s| s.last.to_s } } }, allow_blank: true
+  validates :latitude, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90, allow_blank: true }
+  validates :longitude, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180, allow_blank: true }
   validate :users_for_shared_access
 
   before_save :nullify_blank_category

--- a/app/views/accounts/_contact_info.html.haml
+++ b/app/views/accounts/_contact_info.html.haml
@@ -31,6 +31,14 @@
           = f.email_field :email
       %tr
         %td
+          .label.top Latitude:
+          = f.text_field :latitude, pattern: "^-?\\d+(\\.\\d+)?$"
+        %td= spacer
+        %td
+          .label.top Longitude:
+          = f.text_field :longitude, pattern: "^-?\\d+(\\.\\d+)?$"
+      %tr
+        %td
           = render "shared/address", f: f, asset: @account, type: :billing, title: :billing_address
         %td= spacer
         %td

--- a/app/views/accounts/_sidebar_show.html.haml
+++ b/app/views/accounts/_sidebar_show.html.haml
@@ -3,6 +3,12 @@
 - pipeline = @account.opportunities.pipeline.map(&:weighted_amount).compact.sum
 
 .panel#summary
+  - if @account.latitude.present? && @account.longitude.present?
+    %div
+      %b= link_to "View on Google Maps", "https://www.google.com/maps/search/?api=1&query=#{@account.latitude},#{@account.longitude}", target: "_blank"
+    %div
+      %b= link_to "geo:#{@account.latitude},#{@account.longitude}", "geo:#{@account.latitude},#{@account.longitude}"
+    #map{style: "width: 250px; height: 250px;"}
   - if @account.website
     %div
       %b= link_to(truncate(@account.website, length: 30), @account.website.to_url, :"data-popup" => true, title: t(:open_in_window, @account.website))
@@ -55,3 +61,11 @@
       .tags= tags_for_index(@account)
 
   = hook(:show_account_sidebar_bottom, self, account: @account)
+
+- if @account.latitude.present? && @account.longitude.present?
+  :javascript
+    var map = L.map('map').setView([#{@account.latitude}, #{@account.longitude}], 18);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
+    L.marker([#{@account.latitude}, #{@account.longitude}]).addTo(map);

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,6 +10,9 @@
       #{yield :stylesheet_includes}
     %style= yield :styles
 
+    %link{ rel: "stylesheet", href: "https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" }
+    %script{ src: "https://unpkg.com/leaflet@1.7.1/dist/leaflet.js" }
+
     = javascript_include_tag :application
 
     - unless tabless_layout? || %w(en-US en-GB).include?(I18n.locale.to_s)

--- a/db/migrate/20250805093408_add_latitude_and_longitude_to_accounts.rb
+++ b/db/migrate/20250805093408_add_latitude_and_longitude_to_accounts.rb
@@ -1,0 +1,6 @@
+class AddLatitudeAndLongitudeToAccounts < ActiveRecord::Migration[4.2]
+  def change
+    add_column :accounts, :latitude, :decimal, precision: 10, scale: 6
+    add_column :accounts, :longitude, :decimal, precision: 10, scale: 6
+  end
+end


### PR DESCRIPTION
This change adds latitude and longitude to the Account model, including:
- A database migration to add the new columns.
- Model validations for the new attributes.
- UI fields to edit latitude and longitude.
- A show page that displays a geo: link, a Google Maps link, and a Leaflet map with a pin at the account's coordinates.