### PR TITLE
Fix initial viewport

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,6 +2,7 @@
 %html
   %head
     %meta{ "http-equiv" => "Content-Type", content: "text/html; charset=utf-8" }
+    %meta{ name: "viewport", content: "width=device-width, initial-scale=1.0" }
     %title Fat Free CRM
     == <!-- #{controller.controller_name} : #{controller.action_name} -->
     = stylesheet_link_tag :application


### PR DESCRIPTION
Without
<img width="651" height="382" alt="image" src="https://github.com/user-attachments/assets/c95e7123-b3b7-454d-ae51-e30b84aad1cf" />

With
<img width="1258" height="695" alt="image" src="https://github.com/user-attachments/assets/8b20064c-ba47-4ce3-acf1-f32e9cf7a361" />

Far from perfect, but at least you can see the content!