### PR TITLE
Extend user profile with email preferences

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -144,7 +144,9 @@ class UsersController < ApplicationController
       :aim,
       :yahoo,
       :google,
-      :skype
+      :skype,
+      :subscribe_to_comment_replies,
+      :receive_assigned_notifications
     )
   end
 

--- a/app/models/observers/entity_observer.rb
+++ b/app/models/observers/entity_observer.rb
@@ -19,7 +19,9 @@ class EntityObserver < ActiveRecord::Observer
   private
 
   def send_notification_to_assignee(item)
-    UserMailer.assigned_entity_notification(item, current_user).deliver_later if item.assignee.present? && current_user.present? && can_send_email?
+    if item.assignee.present? && item.assignee.receive_assigned_notifications? && current_user.present? && can_send_email?
+      UserMailer.assigned_entity_notification(item, current_user).deliver_later
+    end
   end
 
   # Need to have a host set before email can be sent

--- a/app/models/polymorphic/comment.rb
+++ b/app/models/polymorphic/comment.rb
@@ -54,7 +54,9 @@ class Comment < ActiveRecord::Base
   def notify_subscribers
     users_to_notify = User.where(id: commentable.subscribed_users.reject { |user_id| user_id == user.id })
     users_to_notify.select(&:emailable?).each do |subscriber|
-      SubscriptionMailer.comment_notification(subscriber, self).deliver_later
+      if subscriber.subscribe_to_comment_replies?
+        SubscriptionMailer.comment_notification(subscriber, self).deliver_later
+      end
     end
   end
 

--- a/app/views/users/_profile.html.haml
+++ b/app/views/users/_profile.html.haml
@@ -58,6 +58,17 @@
             .label #{t :skype}:
             = f.text_field :skype, style: "width:112px"
 
+    .subtitle #{t :email_notifications}
+    .section
+      %table
+        %tr
+          %td
+            = f.check_box :subscribe_to_comment_replies
+            = f.label :subscribe_to_comment_replies, t(:subscribe_to_comment_replies), class: 'check_box'
+        %tr
+          %td
+            = f.check_box :receive_assigned_notifications
+            = f.label :receive_assigned_notifications, t(:receive_assigned_notifications), class: 'check_box'
     .buttonbar
       = f.submit t :save_profile
       #{t :or}

--- a/config/locales/fat_free_crm.en-US.yml
+++ b/config/locales/fat_free_crm.en-US.yml
@@ -260,6 +260,8 @@ en-US:
 
   # Views -> Profile.
   #----------------------------------------------------------------------------
+  subscribe_to_comment_replies: "Subscribe to comment replies by email"
+  receive_assigned_notifications: "Receive assigned notifications by email"
   aim: AOL IM
   already_signed_up: Already signed up?
   alt_email: Alternative email

--- a/db/migrate/20250806025815_add_email_preferences_to_users.rb
+++ b/db/migrate/20250806025815_add_email_preferences_to_users.rb
@@ -1,0 +1,9 @@
+class AddEmailPreferencesToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :subscribe_to_comment_replies, :boolean, default: true, null: false
+    add_column :users, :receive_assigned_notifications, :boolean, default: true, null: false
+
+    # Update existing records
+    User.update_all(subscribe_to_comment_replies: true, receive_assigned_notifications: true)
+  end
+end


### PR DESCRIPTION
This commit introduces two new email preference settings for users:

- `subscribe_to_comment_replies`: Allows users to subscribe or unsubscribe from email notifications for comment replies.
- `receive_assigned_notifications`: Allows users to enable or disable email notifications for assigned entities.

These preferences are added to the `users` table through a new migration, with a default value of `true` for both new and existing users.

The `EntityObserver` and `Comment` model have been updated to respect these new preferences, ensuring that emails are only sent to users who have opted in.

The user profile page has also been updated to include checkboxes for managing these preferences.