### PR TITLE
Bump to bootstrap 5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,7 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'activejob'
 gem 'ransack_ui'
 gem 'vcardigan'
-gem 'bootstrap', '~>5.0.0'
+gem 'bootstrap', '~>5.1.0'
 gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem 'jquery-ui-rails', git: 'https://github.com/jquery-ui-rails/jquery-ui-rails.git', tag: 'v7.0.0' # See https://github.com/jquery-ui-rails/jquery-ui-rails/issues/146

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
     airbrussh (1.5.3)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.3)
-    autoprefixer-rails (10.4.16.0)
+    autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
     base64 (0.3.0)
     bcrypt (3.1.20)
@@ -125,9 +125,9 @@ GEM
     bigdecimal (3.2.2)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    bootstrap (5.0.2)
+    bootstrap (5.1.3)
       autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 2.9.2, < 3)
+      popper_js (>= 2.9.3, < 3)
       sassc-rails (>= 2.0.0)
     brakeman (7.1.0)
       racc
@@ -159,7 +159,6 @@ GEM
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
-    cgi (0.5.0)
     childprocess (5.1.0)
       logger (~> 1.5)
     chronic (0.10.2)
@@ -203,8 +202,7 @@ GEM
     drb (2.2.3)
     dynamic_form (1.2.0)
     email_reply_parser_ffcrm (0.5.0)
-    erb (4.0.4)
-      cgi (>= 0.3.3)
+    erb (5.0.2)
     erubi (1.13.1)
     execjs (2.10.0)
     factory_bot (6.5.4)
@@ -213,8 +211,8 @@ GEM
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
     ffaker (2.24.0)
-    ffi (1.17.1-arm64-darwin)
-    ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
     font-awesome-rails (4.7.0.9)
       railties (>= 3.2, < 9.0)
     formatador (1.1.0)
@@ -520,8 +518,9 @@ GEM
     simple_form (5.3.1)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
-    sprockets (4.2.1)
+    sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
+      logger
       rack (>= 2.2.4, < 4)
     sprockets-rails (3.5.2)
       actionpack (>= 6.1)
@@ -538,7 +537,7 @@ GEM
     stringio (3.1.7)
     temple (0.10.3)
     thor (1.4.0)
-    tilt (2.3.0)
+    tilt (2.6.1)
     timecop (0.9.10)
     timeout (0.4.3)
     tzinfo (2.0.6)
@@ -565,7 +564,7 @@ GEM
     will_paginate (4.0.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.18)
+    zeitwerk (2.7.3)
     zeus (0.17.0)
       method_source (>= 0.6.7)
 
@@ -582,7 +581,7 @@ DEPENDENCIES
   base64
   bigdecimal
   bootsnap
-  bootstrap (~> 5.0.0)
+  bootstrap (~> 5.1.0)
   brakeman
   byebug
   cancancan (>= 3.3.0)


### PR DESCRIPTION
https://blog.getbootstrap.com/2021/08/04/bootstrap-5-1-0/

Later: https://getbootstrap.com/docs/5.1/layout/css-grid/ - not doing this now.