### PR TITLE
Enable Content Security Policy

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,7 +66,9 @@ module ApplicationHelper
   def load_select_popups_for(related, *assets)
     js = generate_js_for_popups(related, *assets)
     content_for(:javascript_epilogue) do
-      raw "$(function() { #{js} });"
+      javascript_tag nonce: true do
+        raw "$(function() { #{js} });"
+      end
     end
   end
 
@@ -330,7 +332,11 @@ module ApplicationHelper
   # Ajax helper to pass browser timezone offset to the server.
   #----------------------------------------------------------------------------
   def get_browser_timezone_offset
-    raw "$.get('#{timezone_path}', {offset: (new Date()).getTimezoneOffset()});" unless session[:timezone_offset]
+    return if session[:timezone_offset]
+
+    javascript_tag nonce: true do
+      raw "$.get('#{timezone_path}', {offset: (new Date()).getTimezoneOffset()});"
+    end
   end
 
   STYLES = { large: "180x180#", medium: "50x50#", small: "25x25#", thumb: "16x16#" }.freeze

--- a/app/views/accounts/_sidebar_show.html.haml
+++ b/app/views/accounts/_sidebar_show.html.haml
@@ -69,9 +69,10 @@
   = hook(:show_account_sidebar_bottom, self, account: @account)
 
 - if @account.latitude.present? && @account.longitude.present?
-  :javascript
-    var map = L.map('map').setView([#{@account.latitude}, #{@account.longitude}], 18);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-    }).addTo(map);
-    L.marker([#{@account.latitude}, #{@account.longitude}]).addTo(map);
+  = javascript_tag nonce: true do
+    :plain
+      var map = L.map('map').setView([#{@account.latitude}, #{@account.longitude}], 18);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+      }).addTo(map);
+      L.marker([#{@account.latitude}, #{@account.longitude}]).addTo(map);

--- a/app/views/admin/fields/_sort_by.html.haml
+++ b/app/views/admin/fields/_sort_by.html.haml
@@ -1,10 +1,11 @@
 - sort_by_menu_items = ["Field name", "Field label", "Field type", "Table name", "Display sequence", "Display block", "Display width", "Max size"].inject([]) do | items, sort_by|
   - items << %Q[{ name: "#{sort_by}", on_select: function() { #{redraw(:sort_by, sort_by.downcase!)} } }]
 
-:plain
-  new crm.Menu({
-    trigger   : "#sort_by",
-    fade      : 500,
-    appear    : 500,
-    menu_items: [ #{raw sort_by_menu_items.join(",")} ]
-  });
+= javascript_tag nonce: true do
+  :plain
+    new crm.Menu({
+      trigger   : "#sort_by",
+      fade      : 500,
+      appear    : 500,
+      menu_items: [ #{raw sort_by_menu_items.join(",")} ]
+    });

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,14 +1,15 @@
 = content_for(:javascript_epilogue) do
-  :plain
-    document.observe("dom:loaded", function() {
-      new Effect.Move("standalone", { x:0, y:-16, mode:"relative", fps:100, duration:0.15, afterFinishInternal: function(effect) {
-        new Effect.Move("standalone", { x:0, y:16, mode:"relative", fps:100, duration:0.15, afterFinishInternal: function(effect) {
-          new Effect.Move("standalone", { x:0, y:-8, mode:"relative", fps:100, duration:0.15, afterFinishInternal: function(effect) {
-            new Effect.Move("standalone", { x:0, y:8, mode:"relative", fps:100, duration:0.15 });
+  = javascript_tag nonce: true do
+    :plain
+      document.observe("dom:loaded", function() {
+        new Effect.Move("standalone", { x:0, y:-16, mode:"relative", fps:100, duration:0.15, afterFinishInternal: function(effect) {
+          new Effect.Move("standalone", { x:0, y:16, mode:"relative", fps:100, duration:0.15, afterFinishInternal: function(effect) {
+            new Effect.Move("standalone", { x:0, y:-8, mode:"relative", fps:100, duration:0.15, afterFinishInternal: function(effect) {
+              new Effect.Move("standalone", { x:0, y:8, mode:"relative", fps:100, duration:0.15 });
+            }});
           }});
         }});
-      }});
-    });
+      });
 
 .standalone#standalone
   = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|

--- a/app/views/entities/_basic_search.html.haml
+++ b/app/views/entities/_basic_search.html.haml
@@ -7,18 +7,19 @@
   %span.sorting_options
     = t(:sort_by, field: link_to(h(current_sort_by), "#", id: :sort_by)).html_safe
 
-:javascript
-  var searchTimeout;
+= javascript_tag nonce: true do
+  :plain
+    var searchTimeout;
 
-  $('#query').on('keydown', function(event) {
-    $el = $(event.target)
-    if (searchTimeout) clearTimeout(searchTimeout);
-    searchTimeout = setTimeout(function () { crm.search($el.val(), '#{controller_name}'); }, 500);
-  });
+    $('#query').on('keydown', function(event) {
+      $el = $(event.target)
+      if (searchTimeout) clearTimeout(searchTimeout);
+      searchTimeout = setTimeout(function () { crm.search($el.val(), '#{controller_name}'); }, 500);
+    });
 
-  new crm.Menu({
-    trigger   : "#sort_by",
-    fade      : 500,
-    appear    : 500,
-    menu_items: [ #{raw sort_by_menu_items.join(",")} ]
-  });
+    new crm.Menu({
+      trigger   : "#sort_by",
+      fade      : 500,
+      appear    : 500,
+      menu_items: [ #{raw sort_by_menu_items.join(",")} ]
+    });

--- a/app/views/home/_events_menu.html.haml
+++ b/app/views/home/_events_menu.html.haml
@@ -5,4 +5,3 @@
     appear    : 500,
     menu_items: [ #{raw sort_by_events.join(",")} ]
   });
-

--- a/app/views/home/_options.html.haml
+++ b/app/views/home/_options.html.haml
@@ -5,8 +5,9 @@
   -# activity_options: Show %{models} %{action_type} performed by %{user} in the past %{period}
   = t(:activity_options, models: link_to(t(h(@asset)).singularize.downcase, "#", id: :asset), action_type: link_to(t(h(@action) + "_past_participle").downcase, "#", id: :event), user: link_to(t(h(@user)), "#", id: :user), period: link_to(t(h(@duration)).downcase, "#", id: :duration)).html_safe
 
-%script
-  = render "assets_menu"
-  = render "events_menu"
-  = render "users_menu"
-  = render "duration_menu"
+= javascript_tag nonce: true do
+  :plain
+    #{ render "assets_menu" }
+    #{ render "events_menu" }
+    #{ render "users_menu" }
+    #{ render "duration_menu" }

--- a/app/views/layouts/_jumpbox.html.haml
+++ b/app/views/layouts/_jumpbox.html.haml
@@ -1,7 +1,8 @@
 - current_auto_complete = session[:auto_complete] || :leads
 = content_for(:javascript_epilogue) do
-  :plain
-    (function ($) {
+  = javascript_tag nonce: true do
+    :plain
+      (function ($) {
       $(function() {
         new crm.Popup({
           trigger     : "#jumper",
@@ -23,8 +24,8 @@
             $("#jumper").removeClass("selected");
           }
         });
-      });
-  })($);
+        });
+      })($);
 
 #jumpbox{ hidden }
   %span#jumpbox_menu= jumpbox(current_auto_complete)

--- a/app/views/layouts/admin/application.html.haml
+++ b/app/views/layouts/admin/application.html.haml
@@ -6,19 +6,21 @@
     == <!-- #{controller.controller_name} : #{controller.action_name} -->
     = stylesheet_link_tag :application
     = stylesheet_link_tag :print, media: 'print'
-    %style= yield :styles
+    = tag.style yield(:styles), nonce: true
 
     = javascript_include_tag :application
     = hook(:javascript_includes, self) {}
 
-    %script{type: "text/javascript"}= yield :javascript
+    = yield :javascript
+
     = csrf_meta_tag
 
   %body.admin
     = render "layouts/admin/header"
     = render "layouts/tabbed"
     = render "layouts/footer"
-    %script{type: "text/javascript"}
-      = "crm.base_url = '#{Setting.base_url}';" unless Setting.base_url.blank?
-      = get_browser_timezone_offset
-      = yield :javascript_epilogue
+    = javascript_tag nonce: true do
+      :plain
+        #{ "crm.base_url = '#{Setting.base_url}';" unless Setting.base_url.blank? }
+    = get_browser_timezone_offset
+    = yield :javascript_epilogue

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,10 +9,10 @@
     = stylesheet_link_tag :print, media: 'print'
     = hook(:stylesheet_includes, self) do
       #{yield :stylesheet_includes}
-    %style= yield :styles
+    = tag.style yield(:styles), nonce: true
 
     %link{ rel: "stylesheet", href: "https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" }
-    %script{ src: "https://unpkg.com/leaflet@1.7.1/dist/leaflet.js" }
+    %script{ src: "https://unpkg.com/leaflet@1.7.1/dist/leaflet.js", nonce: content_security_policy_nonce }
 
     = javascript_include_tag :application
 
@@ -23,13 +23,13 @@
     = csrf_meta_tag
     = hook(:javascript_includes, self)
 
-    :javascript
-      crm.language = "#{I18n.locale}"
-      window.controller = "#{controller.controller_name}"
+    = javascript_tag nonce: true do
+      :plain
+        crm.language = "#{I18n.locale}";
+        window.controller = "#{controller.controller_name}";
 
     - if current_user.present?
-      :javascript
-        #{yield :javascript}
+      = yield :javascript
 
 
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
@@ -43,8 +43,9 @@
       = render "layouts/tabbed"
       = render "layouts/footer"
 
-    %script{type: "text/javascript"}
-      = "crm.base_url = '#{h Setting.base_url}';".html_safe unless Setting.base_url.blank?
-      = get_browser_timezone_offset
-      = content_for :javascript_epilogue
-      = hook(:javascript_epilogue, self)
+    = javascript_tag nonce: true do
+      :plain
+        #{ "crm.base_url = '#{h Setting.base_url}';".html_safe unless Setting.base_url.blank? }
+    = get_browser_timezone_offset
+    = yield :javascript_epilogue
+    = hook(:javascript_epilogue, self)

--- a/app/views/shared/_naming.html.haml
+++ b/app/views/shared/_naming.html.haml
@@ -1,9 +1,10 @@
 - naming_menu_items = %w(before after).map { |naming| options_menu_item(:naming, naming) }
 
-:plain
-  new crm.Menu({
-    trigger   : "#naming",
-    fade      : 500,
-    appear    : 500,
-    menu_items: [ #{raw naming_menu_items.join(",")} ]
-  });
+= javascript_tag nonce: true do
+  :plain
+    new crm.Menu({
+      trigger   : "#naming",
+      fade      : 500,
+      appear    : 500,
+      menu_items: [ #{raw naming_menu_items.join(",")} ]
+    });

--- a/app/views/shared/_search.html.haml
+++ b/app/views/shared/_search.html.haml
@@ -5,11 +5,12 @@
 %div{ style: "margin: 0px 0px 6px 0px" }
   = text_field_tag('query', @current_query, size: 23)
 
-:javascript
-  var searchTimeout;
+= javascript_tag nonce: true do
+  :plain
+    var searchTimeout;
 
-  $('#query').on('keydown', function(event) {
-    $el = $(event.target)
-    if (searchTimeout) clearTimeout(searchTimeout);
-    searchTimeout = setTimeout(function () { crm.search($el.val(), '#{path}'); }, 500);
-  });
+    $('#query').on('keydown', function(event) {
+      $el = $(event.target)
+      if (searchTimeout) clearTimeout(searchTimeout);
+      searchTimeout = setTimeout(function () { crm.search($el.val(), '#{path}'); }, 500);
+    });

--- a/app/views/shared/_select_popup.html.haml
+++ b/app/views/shared/_select_popup.html.haml
@@ -1,19 +1,20 @@
 - singular = popup.to_s.singularize
 
-:plain
-  new crm.Popup({
-    trigger     : "#select_#{singular}",
-    target      : "#jumpbox",
-    under       : "#select_#{singular}",
-    appear      : 300,
-    fade        : 300,
-    before_show : function() {
-      $("#jumpbox_menu").hide();
-      $("#jumpbox_label").html("#{t(popup)}:");
-      $("#jumpbox_label").show();
-      crm.auto_complete("#{popup}", "#{related.class.to_s.downcase.pluralize}/#{related.id}");
-    },
-    after_show  : function() {
-      $("#auto_complete_query").focus();
-    }
-  });
+= javascript_tag nonce: true do
+  :plain
+    new crm.Popup({
+      trigger     : "#select_#{singular}",
+      target      : "#jumpbox",
+      under       : "#select_#{singular}",
+      appear      : 300,
+      fade        : 300,
+      before_show : function() {
+        $("#jumpbox_menu").hide();
+        $("#jumpbox_label").html("#{t(popup)}:");
+        $("#jumpbox_label").show();
+        crm.auto_complete("#{popup}", "#{related.class.to_s.downcase.pluralize}/#{related.id}");
+      },
+      after_show  : function() {
+        $("#auto_complete_query").focus();
+      }
+    });

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -30,4 +30,5 @@
     %td(valign="top" style="text-align: right")
       = avatar_for(@user)
 - if Setting.per_user_locale
-  %script= render "languages"
+  = javascript_tag nonce: true do
+    = render "languages"

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,22 +6,32 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data, "https://*.gravatar.com", "https://*.openstreetmap.org"
+    policy.object_src  :none
+    policy.script_src  :self, :https, "https://unpkg.com"
+    policy.style_src   :self, :https, :unsafe_inline, "https://unpkg.com"
+
+    # Allow http for development
+    if Rails.env.development?
+      policy.default_src :self, :https, :http
+      policy.font_src    :self, :https, :http, :data
+      policy.img_src     :self, :https, :http, :data, "https://*.gravatar.com", "https://*.openstreetmap.org"
+      policy.script_src  :self, :https, :http, "https://unpkg.com"
+      policy.style_src   :self, :https, :http, :unsafe_inline, "https://unpkg.com"
+    end
+
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  # Generate session nonces for permitted importmap and inline scripts
+  config.content_security_policy_nonce_generator = ->(request) { SecureRandom.base64(16) }
+  config.content_security_policy_nonce_directives = %w(script-src style-src)
+
+  # Report violations without enforcing the policy.
+  config.content_security_policy_report_only = true
+end


### PR DESCRIPTION
Enabled Content Security Policy (CSP) in Fat Free CRM using nonces for inline scripts and styles. The policy is initially set to report-only mode and includes allowlists for Gravatar, Leaflet, and OpenStreetMap. It also handles environment-specific rules for local development.

---
*PR created automatically by Jules for task [330213784843227832](https://jules.google.com/task/330213784843227832) started by @CloCkWeRX*