### PR TITLE
Fix FrozenError and sqlite3 compatibility for Rails 8 upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ source 'https://rubygems.org'
 
 case ENV['CI'] && ENV['DB']
 when 'sqlite'
-  gem 'sqlite3', '~> 1.6.8'
+  gem 'sqlite3', '>= 2.1'
 when 'mysql'
   gem 'mysql2'
 when 'postgres'
@@ -84,7 +84,7 @@ group :test do
   gem 'database_cleaner'
   gem 'zeus', platform: :ruby unless ENV["CI"]
   gem 'timecop'
-  gem 'sqlite3', '~> 1.6.8'
+  gem 'sqlite3', '>= 2.1'
   gem 'webrick'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,7 +276,6 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     mini_racer (0.20.0)
       libv8-node (~> 24.12.0.1)
     minitest (6.0.3)
@@ -525,8 +524,8 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.9)
-      mini_portile2 (~> 2.8.0)
+    sqlite3 (2.9.2-arm64-darwin)
+    sqlite3 (2.9.2-x86_64-linux-gnu)
     sshkit (1.25.0)
       base64
       logger
@@ -660,7 +659,7 @@ DEPENDENCIES
   selenium-webdriver
   simple_form
   sprockets-rails (>= 3.0.0)
-  sqlite3 (~> 1.6.8)
+  sqlite3 (>= 2.1)
   thor
   timecop
   tzinfo-data

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,7 @@ module FatFreeCRM
                              Dir[Rails.root.join("app/controllers/entities")]
 
     # Prevent Field class from being reloaded more than once as this clears registered customfields
-    config.autoload_once_paths += [File.expand_path('app/models/fields/field.rb', __dir__)]
+    config.autoload_once_paths += [Rails.root.join('app/models/fields/field.rb').to_s]
 
     # Activate observers that should always be running.
     config.active_record.observers = :lead_observer, :opportunity_observer, :task_observer, :entity_observer unless ARGV.join.include?('assets:precompile')

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_06_025815) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_06_025815) do
   create_table "account_contacts", force: :cascade do |t|
     t.integer "account_id"
     t.integer "contact_id"


### PR DESCRIPTION
This PR fixes a FrozenError that occurred when loading the Rails environment in Rails 8.0.5. The issue was caused by an incorrect path in `config.autoload_once_paths` which was using `File.expand_path(..., __dir__)` inside `config/application.rb`, resolving to a non-existent path. Additionally, it updates the `sqlite3` gem to version `>= 2.1` to meet Rails 8 requirements.

---
*PR created automatically by Jules for task [1906924694096361503](https://jules.google.com/task/1906924694096361503) started by @CloCkWeRX*