### PR TITLE
Add dedicated task show page

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -26,7 +26,17 @@ class TasksController < ApplicationController
   #----------------------------------------------------------------------------
   def show
     @task = Task.tracked_by(current_user).find(params[:id])
+    @comment = Comment.new
+    @timeline = timeline(@task)
     respond_with(@task)
+  end
+
+  # GET /tasks/1/versions                                                  AJAX
+  #----------------------------------------------------------------------------
+  def versions
+    @task = Task.tracked_by(current_user).find(params[:id])
+    @versions = @task.versions.order('created_at DESC')
+    respond_with(@versions)
   end
 
   # GET /tasks/new
@@ -183,6 +193,10 @@ class TasksController < ApplicationController
   end
 
   private
+
+  def timeline(asset)
+    (asset.comments + (asset.respond_to?(:emails) ? asset.emails : [])).sort { |x, y| y.created_at <=> x.created_at }
+  end
 
   # Yields array of current filters and updates the session using new values.
   #----------------------------------------------------------------------------

--- a/app/views/tasks/_assigned.html.haml
+++ b/app/views/tasks/_assigned.html.haml
@@ -11,7 +11,7 @@
 
   .indent
     = link_to(assigned.assignee.full_name, user_path(assigned.assignee)) + ": "
-    = auto_link h(assigned.name)
+    = link_to(h(assigned.name), task_path(assigned))
     - if assigned.asset_id?
       == #{t :related} #{link_to(h(assigned.asset.name), polymorphic_url(assigned.asset))}
     &ndash;

--- a/app/views/tasks/_completed.html.haml
+++ b/app/views/tasks/_completed.html.haml
@@ -12,7 +12,7 @@
       = link_to_task_delete(completed, bucket)
 
   .indent
-    %strike= auto_link h(completed.name)
+    %strike= link_to(h(completed.name), task_path(completed))
     - if completed.asset_id?
       == #{t :related} #{link_to(h(completed.asset.name), polymorphic_url(completed.asset))}
     &ndash;

--- a/app/views/tasks/_pending.html.haml
+++ b/app/views/tasks/_pending.html.haml
@@ -15,7 +15,7 @@
     %label{ id: dom_id(pending, :name) }
       - if pending.user.id != current_user.id
         = t(:task_from, link_to(h(pending.user.full_name), user_path(pending.user))).html_safe + ':'
-      = auto_link h(pending.name)
+      = link_to(h(pending.name), task_path(pending))
       - if pending.asset_id?
         =t :related
         = link_to(h(pending.asset.name), polymorphic_url(pending.asset))

--- a/app/views/tasks/_related.html.haml
+++ b/app/views/tasks/_related.html.haml
@@ -8,7 +8,8 @@
       = link_to(related.assignee.full_name, user_path(related.assignee))
     - else
       = link_to(related.user.full_name, user_path(related.user))
-    = ": " + related.name
+    = ": "
+    = link_to(related.name, task_path(related))
     - if related.asset_id?
       == (#{t :related} #{link_to(related.asset.name, polymorphic_url(related.asset))})
     &ndash;

--- a/app/views/tasks/_sidebar_show.html.haml
+++ b/app/views/tasks/_sidebar_show.html.haml
@@ -1,0 +1,34 @@
+.panel#summary
+
+  .caption #{t :task_summary}
+  %dl
+    %li
+      %dt= @task.category.blank? ? t(:other) : t(@task.category)
+      %tt #{t :category}:
+    %li
+      %dt= t(@task.priority, default: :n_a)
+      %tt #{t :priority}:
+    %li
+      %dt= @task.due_at ? l(@task.due_at, format: :long) : t(:n_a)
+      %tt #{t :due_date}:
+    %li
+      %dt= @task.completed_at ? l(@task.completed_at, format: :long) : t(:n_a)
+      %tt #{t :completed_at}:
+    %li
+      %dt= @task.user.full_name
+      %tt #{t :created_by}:
+    %li
+      %dt= @task.assignee ? @task.assignee.full_name : t(:unassigned)
+      %tt #{t :assigned_to}:
+    - if @task.asset
+      %li
+        %dt= link_to(@task.asset.name, polymorphic_url(@task.asset))
+        %tt #{t :related_asset}:
+
+  - unless @task.background_info.blank?
+    .caption #{t :background_info}
+    = auto_link(simple_format @task.background_info)
+
+  = render "fields/sidebar_show", asset: @task
+
+  = hook(:show_task_sidebar_bottom, self, task: @task)

--- a/app/views/tasks/_title_bar.html.haml
+++ b/app/views/tasks/_title_bar.html.haml
@@ -1,0 +1,10 @@
+.title_tools#menu
+  = link_to_inline(:edit_task, edit_task_path(@task), text: t(:edit)) + " | "
+  = link_to_function(t(:delete) + '?', confirm_delete(@task))
+.title_tools#buttons
+  = view_buttons
+.title#title
+  = h(@task.name)
+  = image_tag("loading.gif", size: :thumb, id: "loading", style: "display: none;")
+
+%div#edit_task{ hidden }

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -1,0 +1,15 @@
+- if (template = template_for_current_view)
+  = render(template, task: @task)
+- else
+
+  -# default view
+
+  = render 'tasks/title_bar', task: @task
+  - content_for :sidebar do
+    = render 'tasks/sidebar_show', task: @task
+  = render "comments/new", commentable: @task
+  = render partial: "shared/timeline", collection: @timeline
+
+  = hook(:show_task_bottom, self, {entity: @task}) do
+
+    = render partial: "versions/versions", locals: {object: @task}

--- a/app/views/tasks/versions.js.haml
+++ b/app/views/tasks/versions.js.haml
@@ -1,0 +1,3 @@
+- versions = @versions.paginate(page: params[:page], per_page: 20)
+$('#versions .list').html('#{ j(render partial: 'versions/version', collection: versions) }')
+$('#versions_pagination').html('#{ j paginate(collection: versions, container: false, params: { action: 'versions' } ) }')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,6 +149,7 @@ Rails.application.routes.draw do
     member do
       put :complete
       put :uncomplete
+      get :versions
     end
   end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -121,6 +121,8 @@ describe TasksController do
     TASK_STATUSES.each do |view|
       it "should render the requested task as JSON for #{view} view" do
         allow(Task).to receive_message_chain(:tracked_by, :find).and_return(task = double("Task"))
+        allow(task).to receive(:comments).and_return([])
+        allow(task).to receive(:emails).and_return([])
         expect(task).to receive(:to_json).and_return("generated JSON")
 
         request.env["HTTP_ACCEPT"] = "application/json"
@@ -130,12 +132,29 @@ describe TasksController do
 
       it "should render the requested task as xml for #{view} view" do
         allow(Task).to receive_message_chain(:tracked_by, :find).and_return(task = double("Task"))
+        allow(task).to receive(:comments).and_return([])
+        allow(task).to receive(:emails).and_return([])
         expect(task).to receive(:to_xml).and_return("generated XML")
 
         request.env["HTTP_ACCEPT"] = "application/xml"
         get :show, params: { id: 42, view: "pending" }
         expect(response.body).to eq("generated XML")
       end
+    end
+
+    it "should render show template for HTML request" do
+      @task = create(:task, user: current_user)
+      get :show, params: { id: @task.id }
+      expect(response).to render_template("tasks/show")
+    end
+  end
+
+  describe "responding to GET versions" do
+    it "should expose versions of the requested task" do
+      @task = create(:task, user: current_user)
+      get :versions, params: { id: @task.id }, xhr: true
+      expect(assigns[:versions]).to eq(@task.versions)
+      expect(response).to render_template("tasks/versions")
     end
   end
 


### PR DESCRIPTION
This change introduces a dedicated show page for Tasks, bringing them in line with other entities like Leads and Contacts. The show page includes a title bar with actions, a sidebar for metadata and custom fields, and a main area for comments and version history. Task names in all list views are now clickable and navigate to this new show page.

---
*PR created automatically by Jules for task [220080762878046059](https://jules.google.com/task/220080762878046059) started by @CloCkWeRX*