### PR TITLE
Remove defunct Yahoo Messenger from User model

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -120,7 +120,6 @@ class Admin::UsersController < Admin::ApplicationController
       :phone,
       :mobile,
       :aim,
-      :yahoo,
       :google,
       :password,
       :password_confirmation,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -142,7 +142,6 @@ class UsersController < ApplicationController
       :phone,
       :mobile,
       :aim,
-      :yahoo,
       :google,
       :subscribe_to_comment_replies,
       :receive_assigned_notifications

--- a/app/models/users/user.rb
+++ b/app/models/users/user.rb
@@ -20,7 +20,6 @@
 #  phone               :string(32)
 #  mobile              :string(32)
 #  aim                 :string(32)
-#  yahoo               :string(32)
 #  google              :string(32)
 #  encrypted_password  :string(255)     default(""), not null
 #  password_salt       :string(255)     default(""), not null

--- a/app/views/users/_profile.html.haml
+++ b/app/views/users/_profile.html.haml
@@ -47,10 +47,6 @@
             = f.text_field :aim, style: "width:112px"
           %td= spacer
           %td
-            .label #{t :yahoo}:
-            = f.text_field :yahoo, style: "width:112px"
-          %td= spacer
-          %td
             .label #{t :google}:
             = f.text_field :google, style: "width:112px"
 

--- a/config/locales/fat_free_crm.cs.yml
+++ b/config/locales/fat_free_crm.cs.yml
@@ -256,7 +256,6 @@ cs:
   use_gravatar: Použít Gravatar
   user: Uživatel
   username: Uživatelské jméno
-  yahoo: Yahoo IM
   forgot_password: Zapomenuté heslo
   login: Přihlásit
   no_account: Nemá účet?

--- a/config/locales/fat_free_crm.de-DE.yml
+++ b/config/locales/fat_free_crm.de-DE.yml
@@ -115,7 +115,6 @@ de:
   admin_tab_plugins: Plugins
   company: Firma
   to_rss: RSS feed
-  yahoo: Yahoo IM
   phone: Telefon
   one_day: Ein Tag
   personal_information: Persönliche Information

--- a/config/locales/fat_free_crm.en-GB.yml
+++ b/config/locales/fat_free_crm.en-GB.yml
@@ -290,7 +290,6 @@ en-GB:
   use_gravatar: Use Gravatar
   user: User
   username: Username
-  yahoo: Yahoo IM
   born_on: Born on
   reports_to: Reports to
   access: Access

--- a/config/locales/fat_free_crm.en-US.yml
+++ b/config/locales/fat_free_crm.en-US.yml
@@ -306,7 +306,6 @@ en-US:
   use_gravatar: Use Gravatar
   user: User
   username: Username
-  yahoo: Yahoo IM
   born_on: Born on
   reports_to: Reports to
   access: Access

--- a/config/locales/fat_free_crm.es-CL.yml
+++ b/config/locales/fat_free_crm.es-CL.yml
@@ -300,7 +300,6 @@ es-CL:
   use_gravatar: Usar Gravatar
   user: Usuario
   username: Nombre de usuario
-  yahoo: Yahoo IM
   born_on: Nacido en
   reports_to: Reports to
   access: Access

--- a/config/locales/fat_free_crm.es.yml
+++ b/config/locales/fat_free_crm.es.yml
@@ -286,7 +286,6 @@ es:
   use_gravatar: Usar Gravatar
   user: Usuario
   username: Nombre de usuario
-  yahoo: Yahoo IM
   born_on: Nacido el
   reports_to: Reportar a
   access: Acceso

--- a/config/locales/fat_free_crm.et.yml
+++ b/config/locales/fat_free_crm.et.yml
@@ -287,7 +287,6 @@ et:
   use_gravatar: Kasuta Gravatar'i
   user: Kasutaja
   username: Kasutajanimi
-  yahoo: Yahoo IM
   born_on: Sünnikuupäev
   reports_to: Raporteerib
   access: Juurdepääs

--- a/config/locales/fat_free_crm.fr-CA.yml
+++ b/config/locales/fat_free_crm.fr-CA.yml
@@ -238,7 +238,6 @@ fr-CA:
   use_gravatar: Utilisez Gravatar
   user: Utilisateur
   username: Nom d'utilisateur
-  yahoo: Yahoo IM
   forgot_password: Mot de passe oublié
   login: Connection
   no_account: Vous ne possédez pas de compte?

--- a/config/locales/fat_free_crm.fr.yml
+++ b/config/locales/fat_free_crm.fr.yml
@@ -292,7 +292,6 @@ fr:
   use_gravatar: Utilisez Gravatar
   user: Utilisateur
   username: Nom d'utilisateur
-  yahoo: Yahoo IM
   born_on: Né le
   reports_to: Rends compte à
   access: Accès

--- a/config/locales/fat_free_crm.it.yml
+++ b/config/locales/fat_free_crm.it.yml
@@ -232,7 +232,6 @@ it:
   use_gravatar: Usa Gravatar
   user: Utente
   username: Username
-  yahoo: Yahoo IM
   forgot_password: Password dimenticata
   login: Login
   no_account: Hai un account?

--- a/config/locales/fat_free_crm.ja.yml
+++ b/config/locales/fat_free_crm.ja.yml
@@ -282,7 +282,6 @@ ja:
   use_gravatar: ユーザのGravatar
   user: ユーザ
   username: ユーザ名
-  yahoo: Yahoo IM
   born_on: 生年月日
   reports_to: マネージャー
   access: アクセス

--- a/config/locales/fat_free_crm.nl.yml
+++ b/config/locales/fat_free_crm.nl.yml
@@ -287,7 +287,6 @@ nl:
   use_gravatar: Gebruik Gravatar
   user: Gebruiker
   username: Gebruiekrsnaam
-  yahoo: Yahoo IM
   born_on: Geboren op
   reports_to: Rapporteerd aan
   access: Toegang

--- a/config/locales/fat_free_crm.pl.yml
+++ b/config/locales/fat_free_crm.pl.yml
@@ -229,7 +229,6 @@ pl:
   use_gravatar: użyj gravatara
   user: Użytkownik
   username: Nazwa użytkownika
-  yahoo: Yahoo IM
   forgot_password: Zapomniałem hasła
   login: Zaloguj
   no_account: Czy posiadasz konto?

--- a/config/locales/fat_free_crm.pt-BR.yml
+++ b/config/locales/fat_free_crm.pt-BR.yml
@@ -294,7 +294,6 @@ pt-BR:
   use_gravatar: usar Gravatar
   user: Usuário
   username: Usuário
-  yahoo: Yahoo IM
   born_on: Nascido em
   reports_to: Reportar para
   access: Acesso

--- a/config/locales/fat_free_crm.ru.yml
+++ b/config/locales/fat_free_crm.ru.yml
@@ -297,7 +297,6 @@ ru:
   use_gravatar: Использовать Gravatar
   user: Пользователь
   username: Логин
-  yahoo: Yahoo IM
   born_on: Дата рождения
   reports_to: Отчеты
   access: Доступ

--- a/config/locales/fat_free_crm.sv-SE.yml
+++ b/config/locales/fat_free_crm.sv-SE.yml
@@ -221,7 +221,6 @@ sv-SE:
   use_gravatar: Använd Gravatar
   user: Användare
   username: Användarnamn
-  yahoo: Yahoo IM
   forgot_password: Glömt lösenord
   login: Logga in
   no_account: Har du inget konto?

--- a/config/locales/fat_free_crm.th.yml
+++ b/config/locales/fat_free_crm.th.yml
@@ -225,7 +225,6 @@ th:
   use_gravatar: ใช้ Gravatar
   user: ผู้ใช้
   username: ชื่อผู้ใช้
-  yahoo: Yahoo IM
   forgot_password: ลืมรหัสผ่าน
   login: เข้าระบบ
   no_account: ไม่มีชื่อในรายการสมาชิก

--- a/config/locales/fat_free_crm.zh-CN.yml
+++ b/config/locales/fat_free_crm.zh-CN.yml
@@ -291,7 +291,6 @@ zh-CN:
   use_gravatar: 使用 Gravatar
   user: 用户
   username: 用户名
-  yahoo: Yahoo IM
   born_on: 出生于
   reports_to: 报告给
   access: 访问

--- a/db/demo/users.yml
+++ b/db/demo/users.yml
@@ -13,7 +13,6 @@
 #  phone               :string(32)
 #  mobile              :string(32)
 #  aim                 :string(32)
-#  yahoo               :string(32)
 #  google              :string(32)
 #  encrypted_password       :string(255)     default(""), not null
 #  password_salt       :string(255)     default(""), not null

--- a/db/migrate/20260412051912_remove_yahoo_from_users.rb
+++ b/db/migrate/20260412051912_remove_yahoo_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveYahooFromUsers < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :users, :yahoo, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_06_025815) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_12_051912) do
   create_table "account_contacts", force: :cascade do |t|
     t.integer "account_id"
     t.integer "contact_id"
@@ -441,7 +441,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_06_025815) do
     t.string "phone", limit: 32
     t.string "mobile", limit: 32
     t.string "aim", limit: 32
-    t.string "yahoo", limit: 32
     t.string "google", limit: 32
     t.string "encrypted_password", default: "", null: false
     t.string "password_salt", default: "", null: false

--- a/spec/factories/user_factories.rb
+++ b/spec/factories/user_factories.rb
@@ -17,7 +17,6 @@ FactoryBot.define do
     phone               { FFaker::PhoneNumber.phone_number }
     mobile              { FFaker::PhoneNumber.phone_number }
     aim                 { nil }
-    yahoo               { nil }
     google              { nil }
     admin               { false }
     encrypted_password  { SecureRandom.hex(64) }

--- a/spec/models/users/user_spec.rb
+++ b/spec/models/users/user_spec.rb
@@ -20,7 +20,6 @@
 #  phone               :string(32)
 #  mobile              :string(32)
 #  aim                 :string(32)
-#  yahoo               :string(32)
 #  google              :string(32)
 #  skype               :string(32)
 #  encrypted_password  :string(255)     default(""), not null


### PR DESCRIPTION
Removed the defunct Yahoo Messenger field from the User model and its associated interfaces and configurations. This included a database migration, updates to controllers, views, factories, demo data, and localization files. Verified with automated tests and visual inspection of the profile edit form.

---
*PR created automatically by Jules for task [7477823201319491519](https://jules.google.com/task/7477823201319491519) started by @CloCkWeRX*