### PR TITLE
Account social media attributes and Wikidata integration

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -281,6 +281,8 @@ module ApplicationHelper
       bluesky: "cloud"
     }
     %i[blog linkedin facebook twitter zoom teams signal instagram mastodon bluesky].each do |site|
+      next unless person.respond_to?(site)
+
       url = person.send(site)
       next if url.blank?
 

--- a/app/models/entities/account.rb
+++ b/app/models/entities/account.rb
@@ -79,6 +79,13 @@ class Account < ActiveRecord::Base
   validates :category, inclusion: { in: proc { Setting.unroll(:account_category).map { |s| s.last.to_s } } }, allow_blank: true
   validates :latitude, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90, allow_blank: true }
   validates :longitude, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180, allow_blank: true }
+  validates_length_of :blog, maximum: 128
+  validates_length_of :linkedin, maximum: 128
+  validates_length_of :facebook, maximum: 128
+  validates_length_of :twitter, maximum: 128
+  validates_length_of :instagram, maximum: 128
+  validates_length_of :mastodon, maximum: 128
+  validates_length_of :bluesky, maximum: 128
   validate :users_for_shared_access
 
   before_save :nullify_blank_category

--- a/app/models/users/user.rb
+++ b/app/models/users/user.rb
@@ -91,17 +91,17 @@ class User < ActiveRecord::Base
             uniqueness: { message: :username_taken, case_sensitive: false },
             presence: { message: :missing_username },
             format: { with: /\A[a-z0-9_-]+\z/i }
-  validates_length_of :google, maximum: 32
-  validates_length_of :blog, maximum: 128
-  validates_length_of :facebook, maximum: 128
-  validates_length_of :twitter, maximum: 128
-  validates_length_of :linkedin, maximum: 128
-  validates_length_of :zoom, maximum: 128
-  validates_length_of :teams, maximum: 128
-  validates_length_of :signal, maximum: 128
-  validates_length_of :instagram, maximum: 128
-  validates_length_of :mastodon, maximum: 128
-  validates_length_of :bluesky, maximum: 128
+  validates :google, length: { maximum: 32 }
+  validates :blog, length: { maximum: 128 }
+  validates :facebook, length: { maximum: 128 }
+  validates :twitter, length: { maximum: 128 }
+  validates :linkedin, length: { maximum: 128 }
+  validates :zoom, length: { maximum: 128 }
+  validates :teams, length: { maximum: 128 }
+  validates :signal, length: { maximum: 128 }
+  validates :instagram, length: { maximum: 128 }
+  validates :mastodon, length: { maximum: 128 }
+  validates :bluesky, length: { maximum: 128 }
   validates :password,
             presence: { if: :password_required? },
             confirmation: true

--- a/app/views/accounts/_edit.html.haml
+++ b/app/views/accounts/_edit.html.haml
@@ -8,6 +8,7 @@
     = render "accounts/top_section",  f: f, edit: true
     = render "fields/edit_custom_field_group", f: f, edit: true
     = render "accounts/contact_info", f: f, edit: true
+    = render "accounts/web",          f: f, edit: true
     = render "fields/groups",         f: f, edit: true
     = render "entities/permissions",  f: f, edit: true, entity: @account
     = hook(:entity_form, self, {f: f, entity: @account})

--- a/app/views/accounts/_new.html.haml
+++ b/app/views/accounts/_new.html.haml
@@ -8,6 +8,7 @@
   = render "fields/edit_custom_field_group", f: f
   = render "shared/add_comment", f: f
   = render "accounts/contact_info", f: f
+  = render "accounts/web", f: f
   = render "fields/groups",  f: f
   = render "entities/permissions",  f: f, entity: @account
   = hook(:entity_form, self, {f: f, entity: @account})

--- a/app/views/accounts/_sidebar_show.html.haml
+++ b/app/views/accounts/_sidebar_show.html.haml
@@ -3,7 +3,7 @@
 - pipeline = @account.opportunities.pipeline.map(&:weighted_amount).compact.sum
 
 .panel#summary
-  - if @account.website
+  - if @account.website.present?
     %div
       %b= link_to(truncate(@account.website, length: 30), @account.website.to_url, :"data-popup" => true, title: t(:open_in_window, @account.website))
   - if @account.email.present?
@@ -13,16 +13,16 @@
   = web_presence_icons(@account)
 
   %div
-    - if @account.toll_free_phone
+    - if @account.toll_free_phone.present?
       == #{t :phone_toll_free}: <b>#{link_to_phone(@account.toll_free_phone)}</b><br />
 
-    - if @account.phone
+    - if @account.phone.present?
       == #{t :phone}: <b>#{link_to_phone(@account.phone)}</b><br />
 
-    - if @account.fax
+    - if @account.fax.present?
       == #{t :fax}: <b>#{link_to_phone(@account.fax)}</b><br />
 
-    - if @account.wikidata_id
+    - if @account.wikidata_id.present?
       %b= link_to t(:wikidata), "https://www.wikidata.org/wiki/#{@account.wikidata_id}", target: "_blank", rel: "noopener noreferrer"
 
     %div= render "shared/address_show", asset: @account, type: 'billing', title: :billing_address

--- a/app/views/accounts/_sidebar_show.html.haml
+++ b/app/views/accounts/_sidebar_show.html.haml
@@ -10,6 +10,8 @@
     %div
       %b= link_to_email(@account.email, 30)
 
+  = web_presence_icons(@account)
+
   %div
     - if @account.toll_free_phone
       == #{t :phone_toll_free}: <b>#{link_to_phone(@account.toll_free_phone)}</b><br />

--- a/app/views/accounts/_web.html.haml
+++ b/app/views/accounts/_web.html.haml
@@ -1,0 +1,38 @@
+- edit ||= false
+- collapsed = session[:account_presence].nil?
+= subtitle :account_presence, collapsed, t(:web_presence)
+.section
+  %small#account_presence_intro{ hidden_if(!collapsed) }
+    = t(:intro, t(:web_presence_small)) unless edit
+  #account_presence{ hidden_if(collapsed) }
+    %table
+      %tr
+        %td
+          .label.top #{t :blog}:
+          = f.text_field :blog
+        %td= spacer
+        %td
+          .label.top #{t :twitter}:
+          = f.text_field :twitter
+      %tr
+        %td
+          .label #{t :linked_in}:
+          = f.text_field :linkedin
+        %td= spacer
+        %td
+          .label #{t :facebook}:
+          = f.text_field :facebook
+      %tr
+        %td
+          .label #{t :instagram}:
+          = f.text_field :instagram
+        %td= spacer
+        %td
+          .label #{t :mastodon}:
+          = f.text_field :mastodon
+      %tr
+        %td
+          .label #{t :bluesky}:
+          = f.text_field :bluesky
+        %td= spacer
+        %td

--- a/db/demo/accounts.yml
+++ b/db/demo/accounts.yml
@@ -47,4 +47,11 @@ account<%= i %>:
   updated_at       : <%= (created_at + rand(36_000).seconds).to_fs(:db) %>
   latitude         : <%= FFaker::Geolocation.lat %>
   longitude        : <%= FFaker::Geolocation.lng %>
+  blog             : <%= %[http://#{company.downcase}.blogger.com] if rand(10) < 8 %>
+  linkedin         : <%= %[http://www.linkedin.com/#{company.downcase}] if rand(10) < 8 %>
+  facebook         : <%= %[http://www.facebook.com/#{company.downcase}] if rand(10) < 8 %>
+  instagram        : <%= %[https://www.instagram.com/#{company.downcase}/] if rand(10) < 8 %>
+  bluesky          : <%= %[https://bsky.app/profile/#{company.downcase}/] if rand(10) < 8 %>
+  mastodon         : <%= %[https://mastodon.social/@#{company.downcase}] if rand(10) < 8 %>
+  twitter          : <%= %[http://www.twitter.com/#{company.downcase}] if rand(10) < 8 %>
 <% end %>

--- a/db/migrate/20260412040905_add_social_media_to_entities_and_users.rb
+++ b/db/migrate/20260412040905_add_social_media_to_entities_and_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSocialMediaToEntitiesAndUsers < ActiveRecord::Migration[7.1]
   def change
     %i[contacts leads].each do |table|

--- a/db/migrate/20260412040909_add_twitter_and_linkedin_to_users.rb
+++ b/db/migrate/20260412040909_add_twitter_and_linkedin_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddTwitterAndLinkedinToUsers < ActiveRecord::Migration[7.1]
   def change
     change_table :users do |t|

--- a/db/migrate/20260412040913_add_blog_to_users.rb
+++ b/db/migrate/20260412040913_add_blog_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddBlogToUsers < ActiveRecord::Migration[7.1]
   def change
     add_column :users, :blog, :string, limit: 128

--- a/db/migrate/20260412062855_remove_yahoo_from_users.rb
+++ b/db/migrate/20260412062855_remove_yahoo_from_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveYahooFromUsers < ActiveRecord::Migration[8.0]
   def change
     remove_column :users, :yahoo, :string

--- a/db/migrate/20260413040024_add_social_media_to_accounts.rb
+++ b/db/migrate/20260413040024_add_social_media_to_accounts.rb
@@ -1,0 +1,11 @@
+class AddSocialMediaToAccounts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :accounts, :blog, :string
+    add_column :accounts, :linkedin, :string
+    add_column :accounts, :facebook, :string
+    add_column :accounts, :twitter, :string
+    add_column :accounts, :bluesky, :string
+    add_column :accounts, :instagram, :string
+    add_column :accounts, :mastodon, :string
+  end
+end

--- a/db/migrate/20260413040024_add_social_media_to_accounts.rb
+++ b/db/migrate/20260413040024_add_social_media_to_accounts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSocialMediaToAccounts < ActiveRecord::Migration[8.0]
   def change
     add_column :accounts, :blog, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_12_062855) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_13_040024) do
   create_table "account_contacts", force: :cascade do |t|
     t.integer "account_id"
     t.integer "contact_id"
@@ -51,6 +51,13 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_12_062855) do
     t.string "wikidata_id"
     t.decimal "latitude", precision: 10, scale: 6
     t.decimal "longitude", precision: 10, scale: 6
+    t.string "blog"
+    t.string "linkedin"
+    t.string "facebook"
+    t.string "twitter"
+    t.string "bluesky"
+    t.string "instagram"
+    t.string "mastodon"
     t.index ["assigned_to"], name: "index_accounts_on_assigned_to"
     t.index ["user_id", "name", "deleted_at"], name: "index_accounts_on_user_id_and_name_and_deleted_at", unique: true
   end

--- a/lib/tasks/ffcrm/wikidata.rake
+++ b/lib/tasks/ffcrm/wikidata.rake
@@ -67,40 +67,28 @@ namespace :ffcrm do
       updates[:background_info] = result[:description].to_s if account.background_info.blank? && result[:description]
       updates[:website] = result[:website].to_s if account.website.blank? && result[:website]
 
-      if account.twitter.blank? && result[:twitter]
-        updates[:twitter] = "https://twitter.com/#{result[:twitter]}"
-      end
+      updates[:twitter] = "https://twitter.com/#{result[:twitter]}" if account.twitter.blank? && result[:twitter]
 
-      if account.linkedin.blank? && result[:linkedin]
-        updates[:linkedin] = "https://www.linkedin.com/company/#{result[:linkedin]}"
-      end
+      updates[:linkedin] = "https://www.linkedin.com/company/#{result[:linkedin]}" if account.linkedin.blank? && result[:linkedin]
 
-      if account.instagram.blank? && result[:instagram]
-        updates[:instagram] = "https://www.instagram.com/#{result[:instagram]}"
-      end
+      updates[:instagram] = "https://www.instagram.com/#{result[:instagram]}" if account.instagram.blank? && result[:instagram]
 
       if account.mastodon.blank? && result[:mastodon]
         m = result[:mastodon].to_s
         updates[:mastodon] = if m.start_with?("http")
                                m
                              elsif m =~ /^@?([^@]+)@(.+)$/
-                               "https://#{$2}/@#{$1}"
+                               "https://#{Regexp.last_match(2)}/@#{Regexp.last_match(1)}"
                              else
                                m
                              end
       end
 
-      if account.facebook.blank? && result[:facebook]
-        updates[:facebook] = "https://www.facebook.com/#{result[:facebook]}"
-      end
+      updates[:facebook] = "https://www.facebook.com/#{result[:facebook]}" if account.facebook.blank? && result[:facebook]
 
-      if account.bluesky.blank? && result[:bluesky]
-        updates[:bluesky] = "https://bsky.app/profile/#{result[:bluesky]}"
-      end
+      updates[:bluesky] = "https://bsky.app/profile/#{result[:bluesky]}" if account.bluesky.blank? && result[:bluesky]
 
-      if account.blog.blank? && result[:blog]
-        updates[:blog] = result[:blog].to_s
-      end
+      updates[:blog] = result[:blog].to_s if account.blog.blank? && result[:blog]
 
       account.update(updates) if updates.any?
 

--- a/lib/tasks/ffcrm/wikidata.rake
+++ b/lib/tasks/ffcrm/wikidata.rake
@@ -15,12 +15,47 @@ namespace :ffcrm do
       sleep(1) if (n % 10).zero? # Throttle requests to avoid hitting rate limits
 
       query = <<-SPARQL
-          SELECT ?description ?website ?address ?logo WHERE {
+          SELECT ?description ?website ?address ?logo ?twitter ?linkedin ?instagram ?mastodon ?facebook ?bluesky ?blog WHERE {
             BIND(wd:#{account.wikidata_id} AS ?item)
             OPTIONAL { ?item schema:description ?description . FILTER(LANG(?description) = "en") }
             OPTIONAL { ?item wdt:P856 ?website . }
             OPTIONAL { ?item wdt:P6375 ?address . }
             OPTIONAL { ?item wdt:P154 ?logo . }
+            OPTIONAL {
+              ?item p:P2002 ?twitter_statement .
+              ?twitter_statement ps:P2002 ?twitter .
+              FILTER NOT EXISTS { ?twitter_statement pq:P582 ?twitter_end_date }
+            }
+            OPTIONAL {
+              ?item p:P4264 ?linkedin_statement .
+              ?linkedin_statement ps:P4264 ?linkedin .
+              FILTER NOT EXISTS { ?linkedin_statement pq:P582 ?linkedin_end_date }
+            }
+            OPTIONAL {
+              ?item p:P2003 ?instagram_statement .
+              ?instagram_statement ps:P2003 ?instagram .
+              FILTER NOT EXISTS { ?instagram_statement pq:P582 ?instagram_end_date }
+            }
+            OPTIONAL {
+              ?item p:P4033 ?mastodon_statement .
+              ?mastodon_statement ps:P4033 ?mastodon .
+              FILTER NOT EXISTS { ?mastodon_statement pq:P582 ?mastodon_end_date }
+            }
+            OPTIONAL {
+              ?item p:P2013 ?facebook_statement .
+              ?facebook_statement ps:P2013 ?facebook .
+              FILTER NOT EXISTS { ?facebook_statement pq:P582 ?facebook_end_date }
+            }
+            OPTIONAL {
+              ?item p:P12361 ?bluesky_statement .
+              ?bluesky_statement ps:P12361 ?bluesky .
+              FILTER NOT EXISTS { ?bluesky_statement pq:P582 ?bluesky_end_date }
+            }
+            OPTIONAL {
+              ?item p:P1581 ?blog_statement .
+              ?blog_statement ps:P1581 ?blog .
+              FILTER NOT EXISTS { ?blog_statement pq:P582 ?blog_end_date }
+            }
           }
       SPARQL
 
@@ -28,10 +63,46 @@ namespace :ffcrm do
 
       next unless result
 
-      account.update(background_info: result[:description].to_s) if account.background_info.blank? && result[:description]
-      account.update(website: result[:website].to_s) if account.website.blank? && result[:website]
-      # Assuming you have a logo field on your account model
-      # account.update(logo: result[:logo].to_s) if account.logo.blank? && result[:logo]
+      updates = {}
+      updates[:background_info] = result[:description].to_s if account.background_info.blank? && result[:description]
+      updates[:website] = result[:website].to_s if account.website.blank? && result[:website]
+
+      if account.twitter.blank? && result[:twitter]
+        updates[:twitter] = "https://twitter.com/#{result[:twitter]}"
+      end
+
+      if account.linkedin.blank? && result[:linkedin]
+        updates[:linkedin] = "https://www.linkedin.com/company/#{result[:linkedin]}"
+      end
+
+      if account.instagram.blank? && result[:instagram]
+        updates[:instagram] = "https://www.instagram.com/#{result[:instagram]}"
+      end
+
+      if account.mastodon.blank? && result[:mastodon]
+        m = result[:mastodon].to_s
+        updates[:mastodon] = if m.start_with?("http")
+                               m
+                             elsif m =~ /^@?([^@]+)@(.+)$/
+                               "https://#{$2}/@#{$1}"
+                             else
+                               m
+                             end
+      end
+
+      if account.facebook.blank? && result[:facebook]
+        updates[:facebook] = "https://www.facebook.com/#{result[:facebook]}"
+      end
+
+      if account.bluesky.blank? && result[:bluesky]
+        updates[:bluesky] = "https://bsky.app/profile/#{result[:bluesky]}"
+      end
+
+      if account.blog.blank? && result[:blog]
+        updates[:blog] = result[:blog].to_s
+      end
+
+      account.update(updates) if updates.any?
 
       puts "Updated account: #{account.name}"
     rescue StandardError => e


### PR DESCRIPTION
This PR expands the Account model to include social media attributes, bringing it in parity with Lead and Contact models. It also updates the Wikidata integration to automatically populate these fields when a Wikidata ID is present.

<img width="1008" height="287" alt="image" src="https://github.com/user-attachments/assets/14f796c6-5d20-4812-ad2b-b0c754c76a65" />


Key changes:
- Database migration and model validations for 7 new social media fields on Account.
- New `app/views/accounts/_web.html.haml` partial and integration into existing Account views.
- Updated `ffcrm:wikidata` rake task with expanded SPARQL query and URL mapping logic.
- Robust handling of "end time" (P582) qualifiers in Wikidata to ensure only current social media profiles are imported.
- Bug fix in `ApplicationHelper#web_presence_icons` to prevent `NoMethodError` on models missing certain social media fields.

---
*PR created automatically by Jules for task [5534885375388386009](https://jules.google.com/task/5534885375388386009) started by @CloCkWeRX*