### PR TITLE
Fix jQuery.browser is deprecated warning

### DIFF
--- a/vendor/assets/javascripts/textarea_autocomplete.js
+++ b/vendor/assets/javascripts/textarea_autocomplete.js
@@ -16,7 +16,8 @@
    *    @attr query {Function} will be called to query if there is any match for the user input
    */
   $.fn.areacomplete = function(obj){
-    if( typeof $.browser.msie != 'undefined' ) obj.mode = 'outter';
+    var isIE = /MSIE|Trident/.test(navigator.userAgent);
+    if( isIE ) obj.mode = 'outter';
     this.each(function(index,element){
       if( element.nodeName == 'TEXTAREA' ){
         makeAutoComplete(element,obj);
@@ -24,7 +25,7 @@
     });
   }
 
-  var browser =  {isChrome: $.browser.webkit };
+  var browser =  {isChrome: /AppleWebKit/.test(navigator.userAgent) };
 
   function getTextAreaSelectionEnd(ta) {
      var textArea = ta;//document.getElementById('textarea1');


### PR DESCRIPTION
Replaced deprecated `$.browser` usage in `vendor/assets/javascripts/textarea_autocomplete.js` with standard `navigator.userAgent` checks to eliminate `jquery-migrate` deprecation warnings. Verified the fix by ensuring no more occurrences of `$.browser` or `jQuery.browser` exist in the codebase and running core test suites.

---
*PR created automatically by Jules for task [3304081172809032559](https://jules.google.com/task/3304081172809032559) started by @CloCkWeRX*