### PR TITLE
Extend website JSON-LD parsing for social media links

### DIFF
--- a/app/jobs/account_website_job.rb
+++ b/app/jobs/account_website_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/http'
 require 'nokogiri'
 require 'json'
@@ -6,7 +8,7 @@ class AccountWebsiteJob < ApplicationJob
   queue_as :default
 
   def perform(account)
-    return unless account.website.present?
+    return if account.website.blank?
 
     uri = URI.parse(account.website)
     uri = URI.parse("http://#{account.website}") unless uri.scheme
@@ -30,14 +32,10 @@ class AccountWebsiteJob < ApplicationJob
       objects = data.is_a?(Array) ? data : [data]
 
       # Handle @graph
-      if data.is_a?(Hash) && data['@graph']
-        objects += data['@graph']
-      end
+      objects += data['@graph'] if data.is_a?(Hash) && data['@graph']
 
       objects.each do |obj|
-        if obj['@type'] == 'Organization'
-          update_account_from_org(account, obj)
-        end
+        update_account_from_org(account, obj) if obj['@type'] == 'Organization'
       end
     end
   end
@@ -55,17 +53,18 @@ class AccountWebsiteJob < ApplicationJob
       Array(org['sameAs']).each do |url|
         next unless url.is_a?(String)
 
-        if url.match?(%r{facebook\.com/})
+        case url
+        when %r{facebook\.com/}
           updates[:facebook] ||= url if account.facebook.blank?
-        elsif url.match?(%r{instagram\.com/})
+        when %r{instagram\.com/}
           updates[:instagram] ||= url if account.instagram.blank?
-        elsif url.match?(%r{(twitter\.com|x\.com)/})
+        when %r{(twitter\.com|x\.com)/}
           updates[:twitter] ||= url if account.twitter.blank?
-        elsif url.match?(%r{linkedin\.com/})
+        when %r{linkedin\.com/}
           updates[:linkedin] ||= url if account.linkedin.blank?
-        elsif url.match?(%r{bsky\.app/})
+        when %r{bsky\.app/}
           updates[:bluesky] ||= url if account.bluesky.blank?
-        elsif url.match?(%r{mastodon})
+        when /mastodon/
           updates[:mastodon] ||= url if account.mastodon.blank?
         end
       end
@@ -81,14 +80,12 @@ class AccountWebsiteJob < ApplicationJob
       account.save(validate: false)
     end
 
-    if org['address'].present? && (org['address']['@type'] == 'PostalAddress' || org['address'].is_a?(Hash))
-      update_address(account, org['address'])
-    end
+    update_address(account, org['address']) if org['address'].present? && (org['address']['@type'] == 'PostalAddress' || org['address'].is_a?(Hash))
   end
 
   def update_address(account, addr_data)
     address = account.billing_address || account.addresses.new(address_type: 'Billing')
-    return unless address.blank?
+    return if address.present?
 
     address.street1 = addr_data['streetAddress'] if addr_data['streetAddress'].present?
     address.city = addr_data['addressLocality'] if addr_data['addressLocality'].present?

--- a/app/jobs/account_website_job.rb
+++ b/app/jobs/account_website_job.rb
@@ -51,6 +51,26 @@ class AccountWebsiteJob < ApplicationJob
     updates[:email] = org['email'] if account.email.blank? && org['email'].present?
     updates[:fax] = org['faxNumber'] if account.fax.blank? && org['faxNumber'].present?
 
+    if org['sameAs'].present?
+      Array(org['sameAs']).each do |url|
+        next unless url.is_a?(String)
+
+        if url.match?(%r{facebook\.com/})
+          updates[:facebook] ||= url if account.facebook.blank?
+        elsif url.match?(%r{instagram\.com/})
+          updates[:instagram] ||= url if account.instagram.blank?
+        elsif url.match?(%r{(twitter\.com|x\.com)/})
+          updates[:twitter] ||= url if account.twitter.blank?
+        elsif url.match?(%r{linkedin\.com/})
+          updates[:linkedin] ||= url if account.linkedin.blank?
+        elsif url.match?(%r{bsky\.app/})
+          updates[:bluesky] ||= url if account.bluesky.blank?
+        elsif url.match?(%r{mastodon})
+          updates[:mastodon] ||= url if account.mastodon.blank?
+        end
+      end
+    end
+
     if org['geo'].present? && org['geo']['@type'] == 'GeoCoordinates'
       updates[:latitude] = org['geo']['latitude'].to_f if account.latitude.blank? && org['geo']['latitude'].present?
       updates[:longitude] = org['geo']['longitude'].to_f if account.longitude.blank? && org['geo']['longitude'].present?

--- a/spec/jobs/account_website_job_spec.rb
+++ b/spec/jobs/account_website_job_spec.rb
@@ -67,6 +67,62 @@ RSpec.describe AccountWebsiteJob, type: :job do
     expect(address.country).to eq('US')
   end
 
+  it 'updates account social media fields from JSON-LD sameAs array' do
+    html = <<-HTML
+      <html>
+        <body>
+          <script type="application/ld+json">
+            {
+              "@context": "https://schema.org",
+              "@type": "Organization",
+              "sameAs": [
+                "https://www.facebook.com/example",
+                "https://www.instagram.com/example",
+                "https://twitter.com/example",
+                "https://www.linkedin.com/company/example",
+                "https://bsky.app/profile/example.bsky.social",
+                "https://mastodon.social/@example"
+              ]
+            }
+          </script>
+        </body>
+      </html>
+    HTML
+    allow(@http_double).to receive(:get).and_return(double(is_a?: true, body: html))
+    allow(@http_double).to receive(:request_get).and_return(double(is_a?: true, body: html))
+
+    expect {
+      AccountWebsiteJob.perform_now(account)
+    }.to change { account.reload.facebook }.to('https://www.facebook.com/example')
+    .and change { account.instagram }.to('https://www.instagram.com/example')
+    .and change { account.twitter }.to('https://twitter.com/example')
+    .and change { account.linkedin }.to('https://www.linkedin.com/company/example')
+    .and change { account.bluesky }.to('https://bsky.app/profile/example.bsky.social')
+    .and change { account.mastodon }.to('https://mastodon.social/@example')
+  end
+
+  it 'updates account social media fields from JSON-LD sameAs string' do
+    html = <<-HTML
+      <html>
+        <body>
+          <script type="application/ld+json">
+            {
+              "@context": "https://schema.org",
+              "@type": "Organization",
+              "sameAs": "https://www.facebook.com/example"
+            }
+          </script>
+        </body>
+      </html>
+    HTML
+    allow(@http_double).to receive(:get).and_return(double(is_a?: true, body: html))
+    allow(@http_double).to receive(:request_get).and_return(double(is_a?: true, body: html))
+
+    expect {
+      AccountWebsiteJob.perform_now(account)
+    }.to change { account.reload.facebook }.to('https://www.facebook.com/example')
+  end
+
   it 'does not overwrite existing fields' do
     account.update(phone: '555-5555')
     expect {


### PR DESCRIPTION
Extended the `AccountWebsiteJob` to extract social media profile URLs from a website's JSON-LD `sameAs` metadata. Supported platforms include Facebook, Instagram, Twitter/X, LinkedIn, Bluesky, and Mastodon. The job only updates fields that are currently blank to avoid overwriting user-provided data. Unit tests were added to verify the new parsing logic for various `sameAs` formats.

---
*PR created automatically by Jules for task [15758005451832059998](https://jules.google.com/task/15758005451832059998) started by @CloCkWeRX*



<img width="967" height="595" alt="image" src="https://github.com/user-attachments/assets/1d412055-58bd-40b2-9402-c6b46b8928c5" />


<img width="351" height="131" alt="image" src="https://github.com/user-attachments/assets/5e8510a0-283d-486a-9f0f-3a8b9c2774ab" />
