### PR TITLE
Extend JSON-LD parsing for WebPage about Organization

### DIFF
--- a/app/jobs/account_website_job.rb
+++ b/app/jobs/account_website_job.rb
@@ -20,22 +20,55 @@ class AccountWebsiteJob < ApplicationJob
     json_ld_scripts = doc.css('script[type="application/ld+json"]')
 
     json_ld_scripts.each do |script|
-      begin
-        data = JSON.parse(script.content)
-      rescue JSON::ParserError
-        next
+      process_json_ld(account, script.content)
+    end
+  end
+
+  private
+
+  def process_json_ld(account, content)
+    begin
+      data = JSON.parse(content)
+    rescue JSON::ParserError
+      return
+    end
+
+    return unless data
+
+    # Handle both single object and array of objects
+    objects = data.is_a?(Array) ? data : [data]
+
+    # Handle @graph
+    objects += data['@graph'] if data.is_a?(Hash) && data['@graph']
+    objects.compact!
+    objects.uniq!
+
+    objects.each do |obj|
+      next unless obj.is_a?(Hash)
+
+      type = obj['@type']
+      if (type == 'Organization' || Array(type).include?('Organization'))
+        update_account_from_org(account, obj)
       end
 
-      next unless data
+      about = obj['about']
+      if (type == 'WebPage' || Array(type).include?('WebPage')) && about
+        Array(about).each do |about_obj|
+          next unless about_obj.is_a?(Hash)
 
-      # Handle both single object and array of objects
-      objects = data.is_a?(Array) ? data : [data]
-
-      # Handle @graph
-      objects += data['@graph'] if data.is_a?(Hash) && data['@graph']
-
-      objects.each do |obj|
-        update_account_from_org(account, obj) if obj['@type'] == 'Organization'
+          about_type = about_obj['@type']
+          if about_type == 'Organization' || Array(about_type).include?('Organization')
+            update_account_from_org(account, about_obj)
+          elsif about_obj['@id']
+            # Look for the referenced object in the graph
+            referenced_org = objects.find do |o|
+              o.is_a?(Hash) &&
+                o['@id'] == about_obj['@id'] &&
+                (o['@type'] == 'Organization' || Array(o['@type']).include?('Organization'))
+            end
+            update_account_from_org(account, referenced_org) if referenced_org
+          end
+        end
       end
     end
   end
@@ -85,7 +118,7 @@ class AccountWebsiteJob < ApplicationJob
 
   def update_address(account, addr_data)
     address = account.billing_address || account.addresses.new(address_type: 'Billing')
-    return if address.present?
+    return if address.persisted?
 
     address.street1 = addr_data['streetAddress'] if addr_data['streetAddress'].present?
     address.city = addr_data['addressLocality'] if addr_data['addressLocality'].present?


### PR DESCRIPTION
This change enhances the metadata scraping in `AccountWebsiteJob` to support more complex JSON-LD structures commonly used by SEO plugins like Yoast. Specifically, it now looks for `Organization` data that is associated with a `WebPage` via the `about` property.

Key improvements:
- **Nested Organization Support:** The job can now find an `Organization` even if it is not a top-level object in the JSON-LD, by following the `about` property of a `WebPage`.
- **Graph Reference Support:** It correctly resolves `@id` references within the `@graph`, allowing it to link a `WebPage` to an `Organization` defined elsewhere in the same script.
- **Robust Type Checking:** Supports schema objects that provide multiple types in an array (e.g., `["Organization", "LocalBusiness"]`).
- **Bug Fix:** Fixed `update_address` which was failing to save new addresses because of an incorrect `address.present?` check (which is always true for newly initialized objects).
- **Refactoring:** Cleaned up the `perform` method by moving JSON-LD processing logic into private helper methods.

---
*PR created automatically by Jules for task [3975854421755843137](https://jules.google.com/task/3975854421755843137) started by @CloCkWeRX*