### PR TITLE
Document Lead Import CSV format

### DIFF
--- a/app/views/admin/leads/index.html.haml
+++ b/app/views/admin/leads/index.html.haml
@@ -4,6 +4,16 @@
 .remote
   = form_tag import_admin_leads_path, multipart: true do
     .section
+      .subtitle
+        = t(:leads_import_help)
+      %p
+        = t(:leads_import_supported_headers)
+      %p
+        %strong= t(:leads_import_example_header)
+        %pre
+          = t(:leads_import_example_content)
+      %p
+        %em= t(:leads_import_note)
       %table
         %tr
           %td

--- a/config/locales/fat_free_crm.en-US.yml
+++ b/config/locales/fat_free_crm.en-US.yml
@@ -464,6 +464,11 @@ en-US:
   create_lead: Create Lead
   import_leads: Import Leads
   csv_file: CSV File
+  leads_import_help: "Upload a CSV file to import leads. The first row should contain the headers. The importer will automatically map headers to lead attributes."
+  leads_import_supported_headers: "Supported headers include: First Name, Last Name, Email, Company, Title, Phone, Mobile, Source, Status, Referred By, Rating, Do Not Call, and Background Info."
+  leads_import_example_header: "Example CSV format:"
+  leads_import_example_content: "First Name,Last Name,Email,Company\nJohn,Doe,john.doe@example.com,ACME Corp\nJane,Smith,jane.smith@example.com,Global Industries"
+  leads_import_note: "Note: Custom fields can also be imported using their labels or column names (e.g., cf_custom_field)."
   create_opp_for_contact: You can optionally create an opportunity for the %{value}
     contact by specifying the name, current stage, estimated closing date, sale probability,
     amount of the deal, and the discount offered.


### PR DESCRIPTION
This change adds documentation to the Leads Import page in the admin section. It describes the supported CSV format, lists common headers, and provides a clear example that users can follow. It also mentions that custom fields are supported.

---
*PR created automatically by Jules for task [15553625144945464700](https://jules.google.com/task/15553625144945464700) started by @CloCkWeRX*