### PR TITLE
Move comment notifications to a background job to prevent timeouts

### DIFF
--- a/app/jobs/comment_notification_job.rb
+++ b/app/jobs/comment_notification_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CommentNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform(comment)
+    return unless comment.present?
+
+    commentable = comment.commentable
+    user = comment.user
+
+    users_to_notify = User.where(id: commentable.subscribed_users.reject { |user_id| user_id == user.id })
+    users_to_notify.select(&:emailable?).each do |subscriber|
+      if subscriber.subscribe_to_comment_replies?
+        SubscriptionMailer.comment_notification(subscriber, comment).deliver_now
+      end
+    end
+  end
+end

--- a/app/models/polymorphic/comment.rb
+++ b/app/models/polymorphic/comment.rb
@@ -32,7 +32,8 @@ class Comment < ActiveRecord::Base
                   ignore: [:state]
 
   before_create :subscribe_mentioned_users
-  after_create :subscribe_user_to_entity, :notify_subscribers
+  after_create :subscribe_user_to_entity
+  after_create_commit :notify_subscribers
 
   def expanded?
     state == "Expanded"
@@ -52,10 +53,7 @@ class Comment < ActiveRecord::Base
 
   # Notify subscribed users when a comment is added, unless user created this comment
   def notify_subscribers
-    users_to_notify = User.where(id: commentable.subscribed_users.reject { |user_id| user_id == user.id })
-    users_to_notify.select(&:emailable?).each do |subscriber|
-      SubscriptionMailer.comment_notification(subscriber, self).deliver_later if subscriber.subscribe_to_comment_replies?
-    end
+    CommentNotificationJob.perform_later(self)
   end
 
   # If a user is mentioned in the comment body, subscribe them to the entity

--- a/spec/jobs/comment_notification_job_spec.rb
+++ b/spec/jobs/comment_notification_job_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe CommentNotificationJob do
+  let(:subscriber) { create(:user) }
+  let(:entity) { create(:lead, subscribed_users: [subscriber.id]) }
+  let(:comment) { create(:comment, commentable: entity) }
+
+  before(:each) do
+    allow(SubscriptionMailer).to receive_message_chain(:comment_notification, :deliver_now)
+  end
+
+  it "should notify subscribers when a comment is added" do
+    CommentNotificationJob.perform_now(comment)
+    expect(SubscriptionMailer).to have_received(:comment_notification).with(subscriber, comment)
+  end
+
+  it "should not notify the user who created the comment" do
+    user = comment.user
+    entity.update(subscribed_users: [subscriber.id, user.id])
+    CommentNotificationJob.perform_now(comment)
+    expect(SubscriptionMailer).not_to have_received(:comment_notification).with(user, comment)
+  end
+
+  it "should not notify suspended users" do
+    subscriber.update(suspended_at: Time.now)
+    CommentNotificationJob.perform_now(comment)
+    expect(SubscriptionMailer).not_to have_received(:comment_notification).with(subscriber, comment)
+  end
+
+  it "should not notify users awaiting approval" do
+    subscriber.update(sign_in_count: 0, suspended_at: Time.now)
+    allow(Setting).to receive(:user_signup).and_return(:needs_approval)
+    CommentNotificationJob.perform_now(comment)
+    expect(SubscriptionMailer).not_to have_received(:comment_notification).with(subscriber, comment)
+  end
+
+  it "should not notify users who opted out of comment replies" do
+    subscriber.update(subscribe_to_comment_replies: false)
+    CommentNotificationJob.perform_now(comment)
+    expect(SubscriptionMailer).not_to have_received(:comment_notification).with(subscriber, comment)
+  end
+end

--- a/spec/models/polymorphic/comment_spec.rb
+++ b/spec/models/polymorphic/comment_spec.rb
@@ -46,32 +46,10 @@ describe Comment do
   describe "notify_subscribers" do
     let(:subscriber) { create(:user) }
     let(:entity) { create(:lead, subscribed_users: [subscriber.id]) }
-    before(:each) do
-      allow(SubscriptionMailer).to receive_message_chain(:comment_notification, :deliver_later)
-    end
 
-    it "should notify subscribers when a comment is added" do
+    it "should enqueue CommentNotificationJob when a comment is created" do
+      expect(CommentNotificationJob).to receive(:perform_later).with(instance_of(Comment))
       Comment.create!(comment: "Hello", user: create(:user), commentable: entity)
-      expect(SubscriptionMailer).to have_received(:comment_notification).with(subscriber, instance_of(Comment))
-    end
-
-    it "should not notify the user who created the comment" do
-      user = create(:user, confirmed_at: Time.now, email: "user@example.com")
-      Comment.create!(comment: "Hello", user: user, commentable: entity)
-      expect(SubscriptionMailer).not_to have_received(:comment_notification).with(user, instance_of(Comment))
-    end
-
-    it "should not notify suspended users" do
-      subscriber.update(suspended_at: Time.now)
-      Comment.create!(comment: "Hello", user: create(:user), commentable: entity)
-      expect(SubscriptionMailer).not_to have_received(:comment_notification).with(subscriber, instance_of(Comment))
-    end
-
-    it "should not notify users awaiting approval" do
-      subscriber.update(sign_in_count: 0, suspended_at: Time.now)
-      allow(Setting).to receive(:user_signup).and_return(:not_allowed)
-      Comment.create!(comment: "Hello", user: create(:user), commentable: entity)
-      expect(SubscriptionMailer).not_to have_received(:comment_notification).with(subscriber, instance_of(Comment))
     end
   end
 end


### PR DESCRIPTION
The `Net::OpenTimeout` error during `CommentsController#create` was caused by synchronous email delivery to multiple subscribers. This PR offloads that work to an asynchronous background job.

Key changes:
- New `CommentNotificationJob` handles the filtering and notification of subscribers.
- `Comment` model updated to use `after_create_commit :notify_subscribers`.
- `Comment#notify_subscribers` now simply enqueues the job.
- Tests updated to verify job enqueuing in the model and correct notification logic in the job.

---
*PR created automatically by Jules for task [6012735318460568616](https://jules.google.com/task/6012735318460568616) started by @CloCkWeRX*