### PR TITLE
Fix task edit from show page to include and save custom fields

### DIFF
--- a/app/views/tasks/_edit.html.haml
+++ b/app/views/tasks/_edit.html.haml
@@ -6,6 +6,7 @@
     = hidden_field_tag "task[asset_type]", "#{@asset.class if @asset}"
 
     = render "tasks/top_section",    f: f, edit: true
+    = render "fields/edit_custom_field_group", f: f, edit: true
     = render "fields/groups", f: f, edit: true
 
     .buttonbar


### PR DESCRIPTION
The task edit form on the show page was missing the partial to render custom fields, preventing them from being edited or saved from that view. This change adds the missing `fields/edit_custom_field_group` partial to `app/views/tasks/_edit.html.haml`.

Key changes:
- Included `= render "fields/edit_custom_field_group", f: f, edit: true` in the task edit form.
- Verified that `TasksController#task_params` correctly permits all custom fields via `*Task.fields.map(&:name)`.
- Confirmed that `tasks/update.js.haml` correctly refreshes the custom fields section on the show page after a successful update.
- Verified the fix with automated feature tests (`spec/features/task_custom_fields_spec.rb` and `spec/features/task_show_edit_spec.rb`).

---
*PR created automatically by Jules for task [12337751535853561563](https://jules.google.com/task/12337751535853561563) started by @CloCkWeRX*