### PR TITLE
Add GHCR build to GitHub Actions, triggered by release

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,0 +1,45 @@
+name: Build and Publish Docker Image
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
A new GitHub Actions workflow has been added to automate the process of building and publishing Docker images to the GitHub Container Registry (GHCR). This workflow is triggered specifically when a new release is published in the repository.

Key features of the workflow:
- **Trigger:** `release` event with `published` type.
- **Registry:** `ghcr.io`.
- **Authentication:** Uses the built-in `GITHUB_TOKEN` with `packages: write` permissions.
- **Tagging:** Automatically generates tags based on semantic versioning (e.g., `v1.2.3`, `v1.2`) and the commit SHA.
- **Security:** Follows least-privilege principles for permissions.

This ensures that every official release of Fat Free CRM is automatically packaged as a Docker image and made available for users via GHCR.

---
*PR created automatically by Jules for task [6933245304631093740](https://jules.google.com/task/6933245304631093740) started by @CloCkWeRX*