### PR TITLE
Swap to platform: windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ gem 'devise', '~> 5.0'
 gem 'devise-i18n'
 gem "devise-encryptable"
 gem "devise-security"
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'tzinfo-data', platforms: %i[windows jruby]
 gem 'activejob'
 gem 'ransack_ui', '~> 3.0.0'
 gem 'vcardigan'


### PR DESCRIPTION
Fix ```[DEPRECATED] Platform :mingw, :mswin, :x64_mingw will be removed in the future. Please use platform :windows instead.```