### PR TITLE
Refactor contact edit form to CSS grid layout

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -647,6 +647,7 @@ DEPENDENCIES
   mini_racer
   mutex_m
   nokogiri (>= 1.8.1)
+  ostruct
   paper_trail (~> 16.0.0)
   pg
   premailer

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -167,6 +167,10 @@ $sidebar_width: 210px;
     width: auto;
   }
   .select2-container { width: 100% !important; }
+
+  .row-full-width {
+    grid-column: 1 / -1;
+  }
 }
 
 /** Mobile grid */

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -169,8 +169,12 @@ $sidebar_width: 210px;
   .select2-container { width: 100% !important; }
 }
 
-.grid-span-2 {
-  grid-column: span 2;
+/** Mobile grid */
+@media (max-width: 768px) {
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
 }
 
 .section {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -153,9 +153,20 @@ $sidebar_width: 210px;
 
 .grid {
   display: grid;
-  grid-template-columns: 240px 240px;
+  grid-template-columns: 1fr 1fr;
   grid-column-gap: 20px;
-  width: 500px;
+
+  .label.req {
+    display: inherit;
+  }
+
+  input, select, textarea {
+    width: 100%;
+  }
+  .check_box input {
+    width: auto;
+  }
+  .select2-container { width: 100% !important; }
 }
 
 .grid-span-2 {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -151,6 +151,17 @@ $sidebar_width: 210px;
   color: dimgray;
   padding-top: 5px; }
 
+.grid {
+  display: grid;
+  grid-template-columns: 240px 240px;
+  grid-column-gap: 20px;
+  width: 500px;
+}
+
+.grid-span-2 {
+  grid-column: span 2;
+}
+
 .section {
   background-color: whitesmoke;
   color: #3f3f3f;

--- a/app/views/contacts/_extra.html.haml
+++ b/app/views/contacts/_extra.html.haml
@@ -5,32 +5,26 @@
   %small#contact_extra_intro{ hidden_if(!collapsed) }
     = t(:intro, t(:extra_info_small)) unless edit
   #contact_extra{ hidden_if(collapsed) }
-    %table
+    .grid
       = hook(:contact_extra_details_form, self, f: f) do
-        %tr
-          %td
-            .label #{t :job_title}:
-            = f.text_field :title
-          %td= spacer
-          %td
-            .label #{t :department}:
-            = f.text_field :department
-        %tr
-          %td
-            .label #{t :alt_email}:
-            = f.email_field :alt_email
-          %td= spacer
-          %td
-            .label #{t :mobile}:
-            = phone_field_with_pattern(f, :mobile)
-        %tr
-          %td
-            = render "shared/address", f: f, asset: @contact, type: 'business', title: :address
-          %td= spacer
-          %td
-            .label #{t :fax}:
-            = phone_field_with_pattern(f, :fax)
-            %div{style: "margin-top:6px"}
-              .check_box
-                = f.check_box :do_not_call, {}, true
-                #{t :do_not_call}
+        %div
+          .label #{t :job_title}:
+          = f.text_field :title
+        %div
+          .label #{t :department}:
+          = f.text_field :department
+        %div
+          .label #{t :alt_email}:
+          = f.email_field :alt_email
+        %div
+          .label #{t :mobile}:
+          = phone_field_with_pattern(f, :mobile)
+        %div
+          = render "shared/address", f: f, asset: @contact, type: 'business', title: :address, grid: true
+        %div
+          .label #{t :fax}:
+          = phone_field_with_pattern(f, :fax)
+          %div{style: "margin-top:6px"}
+            .check_box
+              = f.check_box :do_not_call, {}, true
+              #{t :do_not_call}

--- a/app/views/contacts/_top_section.html.haml
+++ b/app/views/contacts/_top_section.html.haml
@@ -29,7 +29,7 @@
           = user_select(:contact, all_users, current_user)
 
         - if Setting.background_info && Setting.background_info.include?(:contact)
-          .grid-span-2
+          .grid
             .label= t(:background_info) + ':'
             = f.text_area :background_info, rows: 3
 

--- a/app/views/contacts/_top_section.html.haml
+++ b/app/views/contacts/_top_section.html.haml
@@ -28,10 +28,10 @@
           .label #{t :assigned_to}:
           = user_select(:contact, all_users, current_user)
 
-        - if Setting.background_info && Setting.background_info.include?(:contact)
-          .grid
-            .label= t(:background_info) + ':'
-            = f.text_area :background_info, rows: 3
+      - if Setting.background_info && Setting.background_info.include?(:contact)
+        .row-full-width
+          .label= t(:background_info) + ':'
+          = f.text_area :background_info, rows: 3
 
         = render partial: "/shared/tags", locals: {f: f, span: 3, grid: true}
 

--- a/app/views/contacts/_top_section.html.haml
+++ b/app/views/contacts/_top_section.html.haml
@@ -31,7 +31,7 @@
         - if Setting.background_info && Setting.background_info.include?(:contact)
           .grid-span-2
             .label= t(:background_info) + ':'
-            = f.text_area :background_info, style: "width:500px", rows: 3
+            = f.text_area :background_info, rows: 3
 
         = render partial: "/shared/tags", locals: {f: f, span: 3, grid: true}
 

--- a/app/views/contacts/_top_section.html.haml
+++ b/app/views/contacts/_top_section.html.haml
@@ -1,45 +1,38 @@
 
 = hook(:contact_top_section, self, f: f) do
   .section
-    %table
-      %tr
-        %td{class: (@contact.errors['first_name'].present? ? 'fieldWithErrors' : nil)}
-          .label.top{ class: "#{Setting.require_first_names ? 'req' : nil}" } #{t :first_name}:
-          = f.text_field :first_name, autofocus: true, required: (Setting.require_first_names ? "required" : nil)
-        %td= spacer
-        %td{class: (@contact.errors['last_name'].present? ? 'fieldWithErrors' : nil)}
-          .label.top{ class: "#{Setting.require_last_names ? 'req' : nil}" } #{t :last_name}:
-          = f.text_field :last_name, required: (Setting.require_last_names ? "required" : nil)
-      %tr
-        %td
-          .label #{t :email}:
-          = f.email_field :email
-        %td= spacer
-        %td
-          .label #{t :phone}:
-          = f.phone_field :phone
+    .grid
+      %div{class: (@contact.errors['first_name'].present? ? 'fieldWithErrors' : nil)}
+        .label.top{ class: "#{Setting.require_first_names ? 'req' : nil}" } #{t :first_name}:
+        = f.text_field :first_name, autofocus: true, required: (Setting.require_first_names ? "required" : nil)
+      %div{class: (@contact.errors['last_name'].present? ? 'fieldWithErrors' : nil)}
+        .label.top{ class: "#{Setting.require_last_names ? 'req' : nil}" } #{t :last_name}:
+        = f.text_field :last_name, required: (Setting.require_last_names ? "required" : nil)
+      %div
+        .label #{t :email}:
+        = f.email_field :email
+      %div
+        .label #{t :phone}:
+        = f.phone_field :phone
 
-    %table
+    .grid
       = fields_for(@account) do |a|
         = a.hidden_field :user_id
         = a.hidden_field :assigned_to
         = a.hidden_field :access, value: Setting.default_access
-        %tr
-          %td
-            != account_select_or_create(a) do |options|
-              - # Add [-- None --] account choice when editing existing contact that has an account.
-              - options[:include_blank] = "" unless @contact.new_record? || @contact.account.blank?
-          %td= spacer
-          %td
-            .label #{t :assigned_to}:
-            = user_select(:contact, all_users, current_user)
+        %div
+          != account_select_or_create(a) do |options|
+            - # Add [-- None --] account choice when editing existing contact that has an account.
+            - options[:include_blank] = "" unless @contact.new_record? || @contact.account.blank?
+        %div
+          .label #{t :assigned_to}:
+          = user_select(:contact, all_users, current_user)
 
         - if Setting.background_info && Setting.background_info.include?(:contact)
-          %tr
-            %td(colspan="3")
-              .label= t(:background_info) + ':'
-              = f.text_area :background_info, style: "width:500px", rows: 3
+          .grid-span-2
+            .label= t(:background_info) + ':'
+            = f.text_area :background_info, style: "width:500px", rows: 3
 
-        = render partial: "/shared/tags", locals: {f: f, span: 3}
+        = render partial: "/shared/tags", locals: {f: f, span: 3, grid: true}
 
         = hook(:contact_top_section_bottom, self, f: f)

--- a/app/views/contacts/_web.html.haml
+++ b/app/views/contacts/_web.html.haml
@@ -5,49 +5,36 @@
   %small#contact_presence_intro{ hidden_if(!collapsed) }
     = t(:intro, t(:web_presence_small)) unless edit
   #contact_presence{ hidden_if(collapsed) }
-    %table
-      %tr
-        %td
-          .label.top #{t :blog}:
-          = f.url_field :blog
-        %td= spacer
-        %td
-          .label.top #{t :twitter}:
-          = f.text_field :twitter
-      %tr
-        %td
-          .label #{t :linked_in}:
-          = f.text_field :linkedin
-        %td= spacer
-        %td
-          .label #{t :facebook}:
-          = f.text_field :facebook
-      %tr
-        %td
-          .label #{t :instagram}:
-          = f.text_field :instagram
-        %td= spacer
-        %td
-          .label #{t :mastodon}:
-          = f.text_field :mastodon
-      %tr
-        %td
-          .label #{t :bluesky}:
-          = f.text_field :bluesky
-        %td= spacer
-        %td
-      %tr
-        %td
-          .label #{t :zoom}:
-          = f.text_field :zoom
-        %td= spacer
-        %td
-          .label #{t :teams}:
-          = f.text_field :teams
-      %tr
-        %td
-          .label #{t :signal}:
-          = f.text_field :signal
-        %td= spacer
-        %td= spacer
-
+    .grid
+      %div
+        .label.top #{t :blog}:
+        = f.url_field :blog
+      %div
+        .label.top #{t :twitter}:
+        = f.text_field :twitter
+      %div
+        .label #{t :linked_in}:
+        = f.text_field :linkedin
+      %div
+        .label #{t :facebook}:
+        = f.text_field :facebook
+      %div
+        .label #{t :instagram}:
+        = f.text_field :instagram
+      %div
+        .label #{t :mastodon}:
+        = f.text_field :mastodon
+      %div
+        .label #{t :bluesky}:
+        = f.text_field :bluesky
+      %div
+      %div
+        .label #{t :zoom}:
+        = f.text_field :zoom
+      %div
+        .label #{t :teams}:
+        = f.text_field :teams
+      %div
+        .label #{t :signal}:
+        = f.text_field :signal
+      %div

--- a/app/views/entities/_permissions.html.haml
+++ b/app/views/entities/_permissions.html.haml
@@ -17,17 +17,14 @@
       = f.label :access_shared, t(:share_with), style: "cursor:pointer"
 
     #people{ hidden_if(entity.access != "Shared") }
-      %table
-        %tr
-          %td
-            = f.label :user_ids, "#{t(:users)}:"
-            %br
-            = f.select :user_ids, user_options, {}, multiple: true, class: 'select2'
-        %tr
-          %td
-            = f.label :group_ids, "#{t(:groups)}:"
-            %br
-            = f.select :group_ids, group_options, {}, multiple: true, class: 'select2'
+      %div
+        = f.label :user_ids, "#{t(:users)}:"
+        %br
+        = f.select :user_ids, user_options, {}, multiple: true, class: 'select2'
+      %div
+        = f.label :group_ids, "#{t(:groups)}:"
+        %br
+        = f.select :group_ids, group_options, {}, multiple: true, class: 'select2'
 
     - if !edit and entity.is_a?(Lead)
       .radio_box

--- a/app/views/shared/_address.html.haml
+++ b/app/views/shared/_address.html.haml
@@ -3,42 +3,56 @@
 - address = get_address(asset, address_attr)
 
 - same_as_billing ||= false
+- grid ||= false
 
 = f.fields_for(address_attr.to_sym) do |a|
   = a.hidden_field :address_type, value: address_type
   - unless Setting.compound_address
-    - if same_as_billing
-      %div
+    %div
+      - if same_as_billing
         %span(style="float:right")
           = link_to_function(t(:same_as_billing), "crm.copy_address('account_shipping_address', 'account_billing_address')")
-        .label #{t title}:
-    - else
       .label #{t title}:
-    = a.text_area :full_address, style: "width:240px", rows: 4
+      = a.text_area :full_address, style: "width:240px", rows: 4
   - else
-    %table.address(cellpadding="0" cellspacing="0")
-      %tr
-        %td
-          - if same_as_billing
-            %div
-              %span(style="float:right")
-                = link_to_function(t(:same_as_billing), "crm.copy_compound_address('account_billing_address', 'account_shipping_address')")
+    - if grid
+      %div
+        - if same_as_billing
+          %span(style="float:right")
+            = link_to_function(t(:same_as_billing), "crm.copy_compound_address('account_billing_address', 'account_shipping_address')")
+        .label #{t title}:
+        = address_field(a, :street1, "width:240px; margin-top:3px")
+        = address_field(a, :street2, "width:240px;")
+      %div{style: "display: grid; grid-template-columns: 165px 65px; grid-column-gap: 10px; width: 240px;"}
+        = address_field(a, :city, "width:165px;")
+        = address_field(a, :state, "width:65px;")
+      %div{style: "display: grid; grid-template-columns: 80px 150px; grid-column-gap: 10px; width: 240px; margin-top: 6px;"}
+        = address_field(a, :zipcode, "width:80px; margin-top: 0;")
+        = a.country_select(:country, {priority_countries: priority_countries, include_blank: true}, {data: { placeholder: t(:select_a_country)}, class: 'select2'})
+    - else
+      %table.address(cellpadding="0" cellspacing="0")
+        %tr
+          %td
+            - if same_as_billing
+              %div
+                %span(style="float:right")
+                  = link_to_function(t(:same_as_billing), "crm.copy_compound_address('account_billing_address', 'account_shipping_address')")
+                .label #{t title}:
+            - else
               .label #{t title}:
-          - else
-            .label #{t title}:
-          = address_field(a, :street1, "width:240px; margin-top:3px")
-          = address_field(a, :street2, "width:240px;")
-    %table.address(cellpadding="0" cellspacing="0")
-      %tr
-        %td
-          = address_field(a, :city, "width:165px;")
-        %td= spacer
-        %td
-          = address_field(a, :state, "width:60px;")
-    %table.address(cellpadding="0" cellspacing="0")
-      %tr
-        %td
-          = address_field(a, :zipcode, "width:80px;")
-        %td= spacer
-        %td
-          = a.country_select(:country, {priority_countries: priority_countries, include_blank: true}, {data: { placeholder: t(:select_a_country)}, class: 'select2'})
+            = address_field(a, :street1, "width:240px; margin-top:3px")
+            = address_field(a, :street2, "width:240px;")
+      %table.address(cellpadding="0" cellspacing="0")
+        %tr
+          %td
+            = address_field(a, :city, "width:165px;")
+          %td= spacer
+          %td
+            = address_field(a, :state, "width:60px;")
+      %table.address(cellpadding="0" cellspacing="0")
+        %tr
+          %td
+            = address_field(a, :zipcode, "width:80px;")
+          %td= spacer
+          %td
+            = a.country_select(:country, {priority_countries: priority_countries, include_blank: true}, {data: { placeholder: t(:select_a_country)}, class: 'select2'})

--- a/app/views/shared/_tags.html.haml
+++ b/app/views/shared/_tags.html.haml
@@ -1,7 +1,7 @@
 - asset = controller_name.singularize
 - grid ||= false
 - if grid
-  .grid
+  .row-full-width
     .label= t(:tags) + ":"
 
     = f.select :tag_list, Tag.all.map{|t| t.name}, {}, {class: "select2_tag", data: {tags: true, url: url_for(action: 'field_group'), placeholder: t(:select_or_create_tags), multiple: true, asset_id: f.object.try(:id)}, multiple: true}

--- a/app/views/shared/_tags.html.haml
+++ b/app/views/shared/_tags.html.haml
@@ -1,7 +1,7 @@
 - asset = controller_name.singularize
 - grid ||= false
 - if grid
-  .grid-span-2
+  .grid
     .label= t(:tags) + ":"
 
     = f.select :tag_list, Tag.all.map{|t| t.name}, {}, {class: "select2_tag", data: {tags: true, url: url_for(action: 'field_group'), placeholder: t(:select_or_create_tags), multiple: true, asset_id: f.object.try(:id)}, multiple: true}

--- a/app/views/shared/_tags.html.haml
+++ b/app/views/shared/_tags.html.haml
@@ -1,6 +1,13 @@
 - asset = controller_name.singularize
-%tr
-  %td{ valign: :top, colspan: span }
+- grid ||= false
+- if grid
+  .grid-span-2
     .label= t(:tags) + ":"
 
     = f.select :tag_list, Tag.all.map{|t| t.name}, {}, {class: "select2_tag", data: {tags: true, url: url_for(action: 'field_group'), placeholder: t(:select_or_create_tags), multiple: true, asset_id: f.object.try(:id)}, multiple: true}
+- else
+  %tr
+    %td{ valign: :top, colspan: span }
+      .label= t(:tags) + ":"
+
+      = f.select :tag_list, Tag.all.map{|t| t.name}, {}, {class: "select2_tag", data: {tags: true, url: url_for(action: 'field_group'), placeholder: t(:select_or_create_tags), multiple: true, asset_id: f.object.try(:id)}, multiple: true}


### PR DESCRIPTION
https://github.com/fatfreecrm/fat_free_crm/issues/695



This PR transitions the contact edit form from a legacy table-based layout to a modern CSS grid layout. 

Key changes:
1.  **CSS Utilities**: Introduced `.grid` (500px width, 2x240px columns, 20px gap) and `.grid-span-2` in `common.scss` to mimic existing form dimensions.
2.  **Contact Views**: Updated `_top_section.html.haml`, `_extra.html.haml`, and `_web.html.haml` to utilize the new grid system, removing reliance on `<table>` and `spacer` helpers.
3.  **Shared Partials**: Enhanced `_address.html.haml` and `_tags.html.haml` with an optional `grid` local variable. When enabled, these partials omit table tags and render div-based grid markup.
4.  **Permissions**: Simplified `entities/_permissions.html.haml` by replacing internal tables with `div` elements.

These changes improve code maintainability and layout flexibility while preserving the existing visual appearance and supporting backward compatibility for other entities.

---
*PR created automatically by Jules for task [17125148440632675750](https://jules.google.com/task/17125148440632675750) started by @CloCkWeRX*


Mobile:
<img width="441" height="853" alt="image" src="https://github.com/user-attachments/assets/1e4bfcc7-3fc7-48e3-b5b5-58b3fef5e15d" />

Desktop:
<img width="717" height="953" alt="image" src="https://github.com/user-attachments/assets/d9ec05e6-0ce8-435e-8185-554844cf8eb1" />

Not perfect, but better.