### PR TITLE
Leads - Swap to CSS grid, not tables

### DIFF
--- a/app/views/leads/_contact.html.haml
+++ b/app/views/leads/_contact.html.haml
@@ -5,31 +5,31 @@
   %small#lead_contact_intro{ hidden_if(!collapsed) }
     = t(:intro, t(:lead_info_small)) unless edit
   #lead_contact{ hidden_if(collapsed) }
-    %table
-      %tr
-        %td
-          .label.top #{t :job_title}:
-          = f.text_field :title
-        %td= spacer
-        %td
-          .label.top #{t :company}:
-          = f.autocomplete_field :company, autocomplete_account_name_leads_path
-      %tr
-        %td
-          .label #{t :alt_email}:
-          = f.email_field :alt_email
-        %td= spacer
-        %td
-          .label #{t :mobile}:
-          = phone_field_with_pattern(f, :mobile)
-      %tr
-        %td
-          = render "shared/address", f: f, asset: @lead, type: 'business', title: :address
-        %td= spacer
-        %td
-          .label #{t :referred_by}:
-          = f.text_field :referred_by
-          %div{style: "margin-top:6px"}
-            .check_box
-              = f.check_box :do_not_call, {}, true
-              #{t :do_not_call}
+    .grid
+      %div
+        .label.top #{t :job_title}:
+        = f.text_field :title
+
+      %div
+        .label.top #{t :company}:
+        = f.autocomplete_field :company, autocomplete_account_name_leads_path
+
+      %div
+        .label #{t :alt_email}:
+        = f.email_field :alt_email
+
+      %div
+        .label #{t :mobile}:
+        = phone_field_with_pattern(f, :mobile)
+
+      %div
+        = render "shared/address", f: f, asset: @lead, type: 'business', title: :address
+
+      %div
+        .label #{t :referred_by}:
+        = f.text_field :referred_by
+
+        %div{style: "margin-top:6px"}
+          .check_box
+            = f.check_box :do_not_call, {}, true
+            #{t :do_not_call}

--- a/app/views/leads/_status.html.haml
+++ b/app/views/leads/_status.html.haml
@@ -6,31 +6,30 @@
   %small#lead_status_intro{ hidden_if(!collapsed) }
     = t(:intro, t(:lead_status_small)) unless edit
   #lead_status{ hidden_if(collapsed) }
-    %table
-      %tr
-        %td
-          .label.top #{t :assigned_to}:
-          = user_select(:lead, all_users, current_user)
-        %td= spacer
-        %td
-          .label.top #{t :status}:
-          = f.select :status, lead_status_codes_for(@lead), { selected: (@lead.status || "new").to_sym }, { style: "width:160px", class: 'select2' }
-        %td= spacer
-        %td
-          .label.top #{t :rating}:
-          = rating_select "lead[rating]", { id: :lead_rating, selected: @lead.rating, style: "width:160px" }
-      %tr
-        %td
-          .label #{t :source}:
-          - if @campaign && !edit # Create a lead from Campaign landing page: select :campaign as a source and disable the dropdown.
-            = f.select :source, Setting.unroll(:lead_source), { selected: :campaign }, { style: "width:160px;", disabled: true, class: 'select2' }
-            = hidden_field_tag "lead[source]", "campaign"
-          - else
-            = f.select :source, Setting.unroll(:lead_source), { selected: (@lead.source || "other").to_sym }, { style: "width:160px", class: 'select2' }
-        %td= spacer
-        %td{ colspan: 3 }
-          .label #{t :campaign}:
-          - if @campaign && !edit # Create a lead from Campaign landing page: select current campaign and disable the dropdown.
-            = collection_select :lead, :campaign_id, @campaigns, :id, :name, { selected: @campaign.id }, { style: "width:100%", disabled: true, class: 'select2' }
-          - else
-            = collection_select :lead, :campaign_id, @campaigns, :id, :name, { selected: @lead.campaign_id, include_blank: t(:select_none) }, { style: "width:100%", onchange: "crm.flip_campaign_permissions(this.value)", class: 'select2' }
+    .grid
+      %div
+        .label.top #{t :assigned_to}:
+        = user_select(:lead, all_users, current_user)
+
+      %div
+        .label.top #{t :status}:
+        = f.select :status, lead_status_codes_for(@lead), { selected: (@lead.status || "new").to_sym }, { class: 'select2' }
+
+      %div
+        .label.top #{t :rating}:
+        = rating_select "lead[rating]", { id: :lead_rating, selected: @lead.rating, class: 'select2' }
+
+      %div
+        .label #{t :source}:
+        - if @campaign && !edit # Create a lead from Campaign landing page: select :campaign as a source and disable the dropdown.
+          = f.select :source, Setting.unroll(:lead_source), { selected: :campaign }, { disabled: true, class: 'select2' }
+          = hidden_field_tag "lead[source]", "campaign"
+        - else
+          = f.select :source, Setting.unroll(:lead_source), { selected: (@lead.source || "other").to_sym }, { class: 'select2' }
+
+      %div
+        .label #{t :campaign}:
+        - if @campaign && !edit # Create a lead from Campaign landing page: select current campaign and disable the dropdown.
+          = collection_select :lead, :campaign_id, @campaigns, :id, :name, { selected: @campaign.id }, { style: "width:100%", disabled: true, class: 'select2' }
+        - else
+          = collection_select :lead, :campaign_id, @campaigns, :id, :name, { selected: @lead.campaign_id, include_blank: t(:select_none) }, { style: "width:100%", onchange: "crm.flip_campaign_permissions(this.value)", class: 'select2' }

--- a/app/views/leads/_top_section.html.haml
+++ b/app/views/leads/_top_section.html.haml
@@ -1,30 +1,25 @@
 
 = hook(:lead_top_section, self, f: f) do
   .section
-    %table
-      %tr
-        %td{ class: (@lead.errors['first_name'].present? ? 'fieldWithErrors' : nil)}
-          .label.top{ class: "#{Setting.require_first_names ? 'req' : nil}" } #{t :first_name}:
-          = f.text_field :first_name, autofocus: true, required: (Setting.require_first_names ? "required" : nil)
-        %td= spacer
-        %td{ class: (@lead.errors['last_name'].present? ? 'fieldWithErrors' : nil)}
-          .label.top{ class: "#{Setting.require_last_names ? 'req' : nil}" } #{t :last_name}:
-          = f.text_field :last_name, required: (Setting.require_last_names ? "required" : nil)
-      %tr
-        %td
-          .label #{t :email}:
-          = f.text_field :email
-        %td= spacer
-        %td
-          .label #{t :phone}:
-          = phone_field_with_pattern(f, :phone)
+    .grid
+      %div{ class: (@lead.errors['first_name'].present? ? 'fieldWithErrors' : nil)}
+        .label.top{ class: "#{Setting.require_first_names ? 'req' : nil}" } #{t :first_name}:
+        = f.text_field :first_name, autofocus: true, required: (Setting.require_first_names ? "required" : nil)
+      %div{ class: (@lead.errors['last_name'].present? ? 'fieldWithErrors' : nil)}
+        .label.top{ class: "#{Setting.require_last_names ? 'req' : nil}" } #{t :last_name}:
+        = f.text_field :last_name, required: (Setting.require_last_names ? "required" : nil)
+      %div
+        .label #{t :email}:
+        = f.text_field :email
+      %div
+        .label #{t :phone}:
+        = phone_field_with_pattern(f, :phone)
 
       - if Setting.background_info && Setting.background_info.include?(:lead)
-        %tr
-          %td(colspan="3")
-            .label= t(:background_info) + ':'
-            = f.text_area :background_info, style: "width:500px", rows: 3
+        .row-full-width
+          .label= t(:background_info) + ':'
+          = f.text_area :background_info, rows: 3
 
-      = render partial: "/shared/tags", locals: {f: f, span: 3}
+      = render partial: "/shared/tags", locals: {f: f, span: 3, grid: true}
 
       = hook(:lead_top_section_bottom, self, f: f)

--- a/app/views/leads/_web.html.haml
+++ b/app/views/leads/_web.html.haml
@@ -5,49 +5,43 @@
   %small#lead_presence_intro{ hidden_if(!collapsed) }
     = t(:intro, t(:web_presence_small)) unless edit
   #lead_presence{ hidden_if(collapsed) }
-    %table
-      %tr
-        %td
-          .label.top #{t :blog}:
-          = f.text_field :blog
-        %td= spacer
-        %td
-          .label.top #{t :twitter}:
-          = f.text_field :twitter
-      %tr
-        %td
-          .label #{t :linked_in}:
-          = f.text_field :linkedin
-        %td= spacer
-        %td
-          .label #{t :facebook}:
-          = f.text_field :facebook
-      %tr
-        %td
-          .label #{t :instagram}:
-          = f.text_field :instagram
-        %td= spacer
-        %td
-          .label #{t :mastodon}:
-          = f.text_field :mastodon
-      %tr
-        %td
-          .label #{t :bluesky}:
-          = f.text_field :bluesky
-        %td= spacer
-        %td
-      %tr
-        %td
-          .label #{t :zoom}:
-          = f.text_field :zoom
-        %td= spacer
-        %td
-          .label #{t :teams}:
-          = f.text_field :teams
-      %tr
-        %td
-          .label #{t :signal}:
-          = f.text_field :signal
-        %td= spacer
-        %td= spacer
+    .grid
+      %div
+        .label.top #{t :blog}:
+        = f.text_field :blog
+      %div
+        .label.top #{t :twitter}:
+        = f.text_field :twitter
+
+      %div
+        .label #{t :linked_in}:
+        = f.text_field :linkedin
+
+      %div
+        .label #{t :facebook}:
+        = f.text_field :facebook
+
+      %div
+        .label #{t :instagram}:
+        = f.text_field :instagram
+
+      %div
+        .label #{t :mastodon}:
+        = f.text_field :mastodon
+
+      %div
+        .label #{t :bluesky}:
+        = f.text_field :bluesky
+      
+      %div
+        .label #{t :zoom}:
+        = f.text_field :zoom
+
+      %div
+        .label #{t :teams}:
+        = f.text_field :teams
+      %div
+        .label #{t :signal}:
+        = f.text_field :signal
+
 


### PR DESCRIPTION
https://github.com/fatfreecrm/fat_free_crm/issues/695

Desktop:
<img width="1491" height="1002" alt="image" src="https://github.com/user-attachments/assets/c9943643-6339-4731-8b3a-e08ca45d136b" />


Mobile:
<img width="420" height="901" alt="image" src="https://github.com/user-attachments/assets/8cc4a023-7a1f-4e15-969d-e619739cd254" />
