### PR TITLE
Swap navigation on mobile to use bootstrap's offcanvas plugin

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -76,40 +76,74 @@ $color_footer: grey;
   i.fa { 
     font-size: 130%; 
     vertical-align:text-top; }
+
+  // Offcanvas header and title colors
+  .offcanvas-header {
+    background: $color_header_background;
+    color: $color_logo;
+  }
+
   ul {
     margin-left: 15px; }
   li {
     list-style: none;
     margin: 0px 4px 0px 1px; }
-  a:link, a:visited {
-    img {
-      background: none;
-      vertical-align: bottom;
-      float: none;
-      margin-right: 7px; }
-    background: $color_tab_background;
-    color: white;
-    padding: 4px 15px 6px;
-    text-align: center;
-    text-decoration: none;
-    -moz-border-radius: {
-      topleft: 3px;
-      topright: 3px; };
-    -webkit-border-top: {
-      left-radius: 3px;
-      right-radius: 3px; }; }
-  a:hover {
-    background: $color_hover_tab_background;
-    color: $color_hover_tab; }
-  a:link.active, a:visited.active {
-    background: $color_active_tab_background;
-    color: $color_active_tab;
-    text-decoration: none; } }
 
-@media (max-width: 768px) {
-.tabs {
-  a:link.active, a:visited.active {
-    color: yellow; } }
+  // Desktop styles
+  @media (min-width: 992px) {
+    a:link, a:visited {
+      img {
+        background: none;
+        vertical-align: bottom;
+        float: none;
+        margin-right: 7px; }
+      background: $color_tab_background;
+      color: white;
+      padding: 4px 15px 6px;
+      text-align: center;
+      text-decoration: none;
+      -moz-border-radius: {
+        topleft: 3px;
+        topright: 3px; };
+      -webkit-border-top: {
+        left-radius: 3px;
+        right-radius: 3px; }; }
+    a:hover {
+      background: $color_hover_tab_background;
+      color: $color_hover_tab; }
+    a:link.active, a:visited.active {
+      background: $color_active_tab_background;
+      color: $color_active_tab;
+      text-decoration: none; }
+  }
+
+  // Mobile/Offcanvas styles
+  @media (max-width: 991.98px) {
+    .offcanvas-body {
+      background: $color_header_background;
+      padding: 0;
+    }
+    ul {
+      margin: 0;
+      padding: 0;
+    }
+    li {
+      margin: 0;
+    }
+    a.nav-link {
+      padding: 10px 20px;
+      color: white !important;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+      &:hover {
+        background: $color_hover_tab_background;
+        color: $color_hover_tab !important;
+      }
+      &.active {
+        background: $color_active_tab_background;
+        color: $color_active_tab !important;
+      }
+    }
+  }
 }
 
 #footer {

--- a/app/views/layouts/_tabbed.html.haml
+++ b/app/views/layouts/_tabbed.html.haml
@@ -1,13 +1,18 @@
 .navbar.navbar-expand-lg.tabs
   .container-fluid
-    %button{"class" => "navbar-toggler", "type" => "button", "data-bs-toggle" => "collapse", "data-bs-target" => "#navbarNav", "aria-controls" => "navbarNav", "aria-expanded" => "false", "aria-label" => "Toggle navigation"}
+    %button.navbar-toggler{"type" => "button", "data-bs-toggle" => "offcanvas", "data-bs-target" => "#offcanvasNavbar", "aria-controls" => "offcanvasNavbar", "aria-label" => "Toggle navigation"}
       %span.navbar-toggler-icon
-    %ul.navbar-nav.collapse.navbar-collapse.me-auto.mb-2.mg-lg-0{id:"navbarNav"}
-      - tabs.each do |tab|
-        %li.nav-item
-          = link_to(tab[:url], class: tab[:active] ? "nav-link active" : "nav-link") do
-            %i.fa{class: tab[:icon]}
-            = t(tab[:text])
+    .offcanvas.offcanvas-start#offcanvasNavbar{"tabindex" => "-1", "aria-labelledby" => "offcanvasNavbarLabel"}
+      .offcanvas-header
+        %h5.offcanvas-title#offcanvasNavbarLabel Fat Free CRM
+        %button.btn-close{"type" => "button", "data-bs-dismiss" => "offcanvas", "aria-label" => "Close"}
+      .offcanvas-body
+        %ul.navbar-nav.me-auto.mb-2.mb-lg-0
+          - tabs.each do |tab|
+            %li.nav-item
+              = link_to(tab[:url], class: tab[:active] ? "nav-link active" : "nav-link") do
+                %i.fa{class: tab[:icon]}
+                = t(tab[:text])
 
 = show_flash
 %div{ id: 'primary-application-pane' }


### PR DESCRIPTION
This change implements Bootstrap's Offcanvas plugin for the mobile navigation menu in Fat Free CRM. The previous collapse-based navbar has been replaced with a slide-out offcanvas menu from the left (start). Specific SCSS rules were added to ensure the offcanvas body and header match the application's theme and that the desktop tabbed navigation remains unaffected.

---
*PR created automatically by Jules for task [14941319826117617195](https://jules.google.com/task/14941319826117617195) started by @CloCkWeRX*