### PR TITLE
Add token authentication and test coverage for RSS feeds

### DIFF
--- a/app/helpers/campaigns_helper.rb
+++ b/app/helpers/campaigns_helper.rb
@@ -29,8 +29,8 @@ module CampaignsHelper
   # Quick campaign summary for RSS/ATOM feeds.
   #----------------------------------------------------------------------------
   def campaign_summary(campaign)
-    status  = render file: "campaigns/_status.html.haml",  locals: { campaign: campaign }
-    metrics = render file: "campaigns/_metrics.html.haml", locals: { campaign: campaign }
+    status  = render partial: "campaigns/status",  formats: [:html], locals: { campaign: campaign }
+    metrics = render partial: "campaigns/metrics", formats: [:html], locals: { campaign: campaign }
     "#{t(campaign.status)}, " + [status, metrics].map { |str| strip_tags(str) }.join(' ').delete("\n")
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -269,10 +269,9 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    manager.default_strategies(scope: :user).unshift :token_authenticatable
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/config/initializers/token_authenticatable.rb
+++ b/config/initializers/token_authenticatable.rb
@@ -1,0 +1,15 @@
+Warden::Strategies.add(:token_authenticatable) do
+  def valid?
+    params[:authentication_credentials].present?
+  end
+
+  def authenticate!
+    token = params[:authentication_credentials]
+    user = User.find_by(authentication_token: token)
+    if user
+      success!(user)
+    else
+      fail!("Invalid authentication token")
+    end
+  end
+end

--- a/spec/controllers/entities/campaigns_rss_spec.rb
+++ b/spec/controllers/entities/campaigns_rss_spec.rb
@@ -1,0 +1,23 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe CampaignsController, type: :request do
+  it "should allow access to RSS feed via authentication_credentials" do
+    u = User.create!(username: "testuser", email: "test@example.com", password: "Password123!", password_confirmation: "Password123!", authentication_token: "test_token")
+    u.confirm
+    create(:campaign, user: u)
+
+    get "/campaigns.rss", params: { authentication_credentials: "test_token" }
+    expect(response.status).to eq(200)
+    expect(response.media_type).to eq("application/rss+xml")
+  end
+
+  it "should fail access to RSS feed with invalid authentication_credentials" do
+    get "/campaigns.rss", params: { authentication_credentials: "invalid_token" }
+    expect(response.status).to eq(401)
+  end
+
+  it "should fail access to RSS feed without authentication_credentials" do
+    get "/campaigns.rss"
+    expect(response.status).to eq(401)
+  end
+end


### PR DESCRIPTION
The goal was to resolve authentication failures when accessing RSS feeds using the `authentication_credentials` parameter and add corresponding test coverage.

### Key Changes
1.  **Authentication strategy**: Created a custom Warden strategy `:token_authenticatable` that looks up users by their `authentication_token` provided in `params[:authentication_credentials]`.
2.  **Devise configuration**: Registered and enabled this new strategy in the Devise initializer to support token-based authentication for non-navigational formats like RSS and Atom.
3.  **Campaign summary fix**: Refactored `CampaignsHelper#campaign_summary` to use `render partial:` with explicit `formats: [:html]`. This ensures that even when the overall request is for RSS, Rails correctly finds and renders the HTML snippets used in the feed summary.
4.  **Test coverage**: Added `spec/controllers/entities/campaigns_rss_spec.rb` as a request spec to verify that valid tokens grant access, while invalid or missing tokens correctly return `401 Unauthorized`.

These changes ensure that links generated by `ApplicationHelper#links_to_export` work correctly for logged-in users viewing their feeds in RSS readers.

---
*PR created automatically by Jules for task [10405193384732093982](https://jules.google.com/task/10405193384732093982) started by @CloCkWeRX*