### PR TITLE
fix: postgres empty password error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,13 @@ services:
       PASSENGER_APP_ENV: 'production'
       DB_DATABASE: 'fat_free_crm_production'
       DB_USERNAME: 'postgres'
-      DB_PASSWORD: ''
+      DB_PASSWORD: 'password'
       DB_HOST: 'db'
       DB_PORT: 5432
   db:
     image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: 'password'
     restart: always
     volumes:
       - pgdata:/var/lib/postgresql/data


### PR DESCRIPTION
Running the `db` service defined in the `docker-compose.yml` file results in the following error.

```
db-1  | Error: Database is uninitialized and superuser password is not specified.
db-1  |        You must specify POSTGRES_PASSWORD to a non-empty value for the
db-1  |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
db-1  | 
db-1  |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
db-1  |        connections without a password. This is *not* recommended.
db-1  | 
db-1  |        See PostgreSQL documentation about "trust":
db-1  |        https://www.postgresql.org/docs/current/auth-trust.html
db-1 exited with code 1 (restarting)
```