### PR TITLE
Exclude vendor directory from gemspec

### DIFF
--- a/fat_free_crm.gemspec
+++ b/fat_free_crm.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.description = 'An open source, Ruby on Rails customer relationship management platform'
   gem.homepage = 'http://fatfreecrm.com'
   gem.email = ['mike@fatfreecrm.com', 'steveyken@gmail.com', 'daniel.oconnor@gmail.com']
-  gem.files = Dir["{app,config,db,lib,vendor,public,bin,log/script}/**/*", "MIT-LICENSE", "Rakefile", "README.md", "config.ru", "CHANGELOG.md", "CONTRIBUTING.md"]
+  gem.files = Dir["{app,config,db,lib,public,bin,log/script}/**/*", "MIT-LICENSE", "Rakefile", "README.md", "config.ru", "CHANGELOG.md", "CONTRIBUTING.md"]
   gem.version = FatFreeCRM::VERSION::STRING
   gem.required_ruby_version = '>= 3.1'
   gem.license = 'MIT'


### PR DESCRIPTION
This change removes the 'vendor' directory from the `gem.files` glob in `fat_free_crm.gemspec`, ensuring that vendor assets and bundled gems are not included in the packaged gem.

---
*PR created automatically by Jules for task [13195739718863459453](https://jules.google.com/task/13195739718863459453) started by @CloCkWeRX*